### PR TITLE
Fix submodule checkout in CI workflow

### DIFF
--- a/.github/workflows/examples-openiotsdk.yaml
+++ b/.github/workflows/examples-openiotsdk.yaml
@@ -53,7 +53,7 @@ jobs:
                   attempt_limit: 3
                   attempt_delay: 2000
             - name: Checkout submodules
-              run: scripts/checkout_submodules.py --shallow --platform openiotsdk
+              run: scripts/checkout_submodules.py --shallow --recursive --platform openiotsdk
 
             - name: Detect changed paths
               uses: dorny/paths-filter@v2


### PR DESCRIPTION
Checkout submodules recursively to provide the SDK modules

