### PR TITLE
[OIS] Improve unit tests execution

### DIFF
--- a/.github/workflows/examples-openiotsdk.yaml
+++ b/.github/workflows/examples-openiotsdk.yaml
@@ -100,12 +100,12 @@ jobs:
                     examples/lock-app/openiotsdk/build/chip-openiotsdk-lock-app-example.elf \
                     /tmp/bloat_reports/
 
-            - name: Build and run unit tests
+            - name: Build unit tests
               if: github.event_name == 'push' || steps.changed_paths.outputs.openiotsdk == 'true'
-              timeout-minutes: 90
+              id: build_unit_tests
+              timeout-minutes: 10
               run: |
                   scripts/examples/openiotsdk_example.sh unit-tests
-                  scripts/examples/openiotsdk_example.sh -C run unit-tests
 
             - name: Test shell example
               if: steps.build_shell.outcome == 'success'
@@ -120,3 +120,9 @@ jobs:
                   scripts/setup/openiotsdk/network_setup.sh -n $TEST_NETWORK_NAME up
                   scripts/run_in_ns.sh ${TEST_NETWORK_NAME}ns scripts/examples/openiotsdk_example.sh -C test -n ${TEST_NETWORK_NAME}tap lock-app
                   scripts/setup/openiotsdk/network_setup.sh -n $TEST_NETWORK_NAME down
+            
+            - name: Run unit tests
+              if: steps.build_unit_tests.outcome == 'success' && github.event_name == 'pull_request'
+              timeout-minutes: 90
+              run: |
+                  scripts/examples/openiotsdk_example.sh -C run unit-tests

--- a/scripts/examples/openiotsdk_example.sh
+++ b/scripts/examples/openiotsdk_example.sh
@@ -154,7 +154,7 @@ function run_fvp {
     if [[ $IS_TEST -eq 1 ]]; then
         set +e
         expect <<EOF
-        set timeout 1200
+        set timeout 1800
         set retcode -1
         spawn telnet localhost ${TELNET_TERMINAL_PORT}
         expect -re {Test status: (-?\d+)} {


### PR DESCRIPTION
- Increase timeout for a single test in expect section - the CredentialsTest can take more time than 20 minutes.
- Split build and run unit tests in CI workflow and run only with a pull request - this should improve the performance of the CI.