### PR TITLE
[OIS] Make init ZCL Data Model and start server common

### DIFF
--- a/config/openiotsdk/cmake/chip.cmake
+++ b/config/openiotsdk/cmake/chip.cmake
@@ -19,6 +19,8 @@
 #     CMake for CHIP library configuration
 #
 
+get_filename_component(GEN_DIR ${CHIP_ROOT}/zzz_generated/ REALPATH)
+
 # Default CHIP build configuration 
 set(CONFIG_CHIP_PROJECT_CONFIG "main/include/CHIPProjectConfig.h" CACHE STRING "")
 set(CONFIG_CHIP_LIB_TESTS NO CACHE BOOL "")
@@ -37,3 +39,27 @@ endif()
 
 # Add CHIP sources
 add_subdirectory(${OPEN_IOT_SDK_CONFIG} ./chip_build)
+
+function(chip_add_data_model target model_name)
+    target_include_directories(${target} 
+        PUBLIC
+            ${GEN_DIR}/app-common
+            ${GEN_DIR}/${model_name}-app
+    )
+
+    target_sources(${target} 
+        PUBLIC
+            ${GEN_DIR}/${model_name}-app/zap-generated/IMClusterCommandHandler.cpp
+    )
+
+    target_compile_definitions(${target}
+        PUBLIC
+            USE_CHIP_DATA_MODEL
+    )
+
+    include(${CHIP_ROOT}/src/app/chip_data_model.cmake)
+    chip_configure_data_model(${target}
+        INCLUDE_SERVER
+        ZAP_FILE ${CMAKE_CURRENT_SOURCE_DIR}/../${model_name}-common/${model_name}-app.zap
+    )
+endfunction()

--- a/examples/lock-app/openiotsdk/CMakeLists.txt
+++ b/examples/lock-app/openiotsdk/CMakeLists.txt
@@ -19,7 +19,6 @@ cmake_minimum_required(VERSION 3.21)
 get_filename_component(CHIP_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../.. REALPATH)
 get_filename_component(OPEN_IOT_SDK_CONFIG ${CHIP_ROOT}/config/openiotsdk REALPATH)
 get_filename_component(OPEN_IOT_SDK_EXAMPLE_COMMON ${CHIP_ROOT}/examples/platform/openiotsdk REALPATH)
-get_filename_component(GEN_DIR ${CHIP_ROOT}/zzz_generated/ REALPATH)
 
 list(APPEND CMAKE_MODULE_PATH ${OPEN_IOT_SDK_CONFIG}/cmake)
 
@@ -59,11 +58,11 @@ include(chip)
 
 add_subdirectory(${OPEN_IOT_SDK_EXAMPLE_COMMON}/app ./app_build)
 
+chip_add_data_model(openiotsdk-app lock)
+
 target_include_directories(${APP_TARGET} 
     PRIVATE
         main/include
-        ${GEN_DIR}/app-common
-        ${GEN_DIR}/lock-app
 )
 
 target_sources(${APP_TARGET} 
@@ -72,17 +71,10 @@ target_sources(${APP_TARGET}
         main/ZclCallbacks.cpp
         main/LockManager.cpp
         main/LockEndpoint.cpp
-        ${GEN_DIR}/lock-app/zap-generated/IMClusterCommandHandler.cpp
 )
 
 target_link_libraries(${APP_TARGET}
     openiotsdk-app
-)
-
-include(${CHIP_ROOT}/src/app/chip_data_model.cmake)
-chip_configure_data_model(${APP_TARGET}
-    INCLUDE_SERVER
-    ZAP_FILE ${CMAKE_CURRENT_SOURCE_DIR}/../lock-common/lock-app.zap
 )
 
 include(linker)

--- a/examples/platform/openiotsdk/app/openiotsdk_platform.h
+++ b/examples/platform/openiotsdk/app/openiotsdk_platform.h
@@ -66,4 +66,18 @@ int openiotsdk_platform_run(void);
  */
 int openiotsdk_network_init(bool wait);
 
+/**
+ * @brief Run the CHIP sources/components
+ * Initialize ZCL Data Model and start server
+ *
+ * @return EXIT_SUCCESS or EXIT_FAILURE
+ */
+int openiotsdk_chip_run(void);
+
+/**
+ * @brief Shutdown the CHIP sources/components
+ * Stop chip server
+ */
+void openiotsdk_chip_shutdown(void);
+
 #endif /* ! OPENIOTSDK_PLATFORM_H */


### PR DESCRIPTION
Move init ZCL Data Model and start server to openiotsdk-app target. 
Implement openiotsdk_chip_run() and openiotsdk_chip_shutdown(). 
Add chip_add_data_model() cmake function to add a specified data model to the target.
Apply changes in lock-app example.

These changes improve adding new OIS examples. ZCL Data Model initialization and starting server can be shared by using openiotsdk-app target.
