### PR TITLE
[OIS]: Improve build system.

### DIFF
--- a/config/openiotsdk/CMakeLists.txt
+++ b/config/openiotsdk/CMakeLists.txt
@@ -31,7 +31,7 @@ include(util.cmake)
 # Declare configuration variables and define constants
 # ==============================================================================
 # C/C++ compiler flags passed to CHIP build system
-list(APPEND CHIP_CFLAGS \"-Wno-unused-function\")
+list(APPEND CHIP_CFLAGS "'-Wno-unused-function'")
 
 # C compiler flags passed to CHIP build system
 list(APPEND CHIP_CFLAGS_C ${CMAKE_C_FLAGS})
@@ -101,6 +101,7 @@ set(GN_ROOT_TARGET ${CHIP_ROOT}/config/openiotsdk/chip-gn)
 foreach(target ${EXTERNAL_TARGETS})
     get_target_common_compile_flags(EXTERNAL_TARGET_CFLAGS ${target})
     list(APPEND CHIP_CFLAGS ${EXTERNAL_TARGET_CFLAGS})
+    set(EXTERNAL_TARGET_CFLAGS "") # Reset SDK_TARGET_CFLAGS between update
 endforeach()
 
 # Remove duplicated flags
@@ -208,17 +209,29 @@ ExternalProject_Add(
     PREFIX                  ${CMAKE_CURRENT_BINARY_DIR}
     SOURCE_DIR              ${CHIP_ROOT}
     BINARY_DIR              ${CMAKE_CURRENT_BINARY_DIR}
-    CONFIGURE_COMMAND       ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/make_gn_args.py
-                                @args.tmp > args.gn &&
-                            ${GN_EXECUTABLE}
+    CONFIGURE_COMMAND       ""
+    CONFIGURE_HANDLED_BY_BUILD TRUE
+    BUILD_COMMAND           ${CMAKE_COMMAND} -E echo "Starting Matter library build in ${CMAKE_CURRENT_BINARY_DIR}"
+    COMMAND                 ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/make_gn_args.py @args.tmp > args.gn.tmp
+    # Replace the config only if it has changed to avoid triggering unnecessary rebuilds
+    COMMAND                 bash -c "(! diff -q args.gn.tmp args.gn && mv args.gn.tmp args.gn) || true" 
+    # Regenerate the ninja build system
+    COMMAND                 ${GN_EXECUTABLE}
                                 --root=${CHIP_ROOT}
                                 --root-target=${GN_ROOT_TARGET}
                                 --dotfile=${GN_ROOT_TARGET}/.gn
                                 --script-executable=${Python3_EXECUTABLE}
                                 gen --check --fail-on-unused-args ${CMAKE_CURRENT_BINARY_DIR}
-    BUILD_COMMAND           ninja
+    COMMAND                 ninja
+    COMMAND                 ${CMAKE_COMMAND} -E echo "Matter library build complete"
     INSTALL_COMMAND         ""
-    BUILD_BYPRODUCTS        ${CHIP_LIBRARIES}
+    # Byproducts are removed by the clean target removing config and .ninja_deps
+    # allows a rebuild of the external project after the clean target has been run. 
+    BUILD_BYPRODUCTS        ${CMAKE_CURRENT_BINARY_DIR}/args.gn
+                            ${CMAKE_CURRENT_BINARY_DIR}/build.ninja
+                            ${CMAKE_CURRENT_BINARY_DIR}/.ninja_deps
+                            ${CMAKE_CURRENT_BINARY_DIR}/build.ninja.stamp
+                            ${CHIP_LIBRARIES}
     BUILD_ALWAYS            TRUE
     USES_TERMINAL_CONFIGURE TRUE
     USES_TERMINAL_BUILD     TRUE

--- a/config/openiotsdk/util.cmake
+++ b/config/openiotsdk/util.cmake
@@ -61,13 +61,11 @@ endfunction()
 # [Args]:
 #   target - target name
 #   output - output variable name
+# Note: Includes are returned as a generator expression which must be evalued 
+# at build time. 
 function(get_include_directories target output)
   get_property(flags TARGET ${target} PROPERTY INTERFACE_INCLUDE_DIRECTORIES)
-  list(APPEND CFLAG_LIST)
-  foreach(flag ${flags})
-    list(APPEND CFLAG_LIST "\"-isystem${flag}\"")
-  endforeach()
-  set(${output} ${CFLAG_LIST} PARENT_SCOPE)
+  set(${output} "'-isystem$<JOIN:$<TARGET_PROPERTY:${target},INTERFACE_INCLUDE_DIRECTORIES>,'$<COMMA>'-isystem>'" PARENT_SCOPE)
 endfunction()
 
 # Get compile definitions of target build
@@ -76,16 +74,11 @@ endfunction()
 # [Args]:
 #   target - target name
 #   output - output variable name
+# Note: Definitions are returned as a generator expression which must be evalued 
+# at build time. 
 function(get_compile_definitions target output)
   get_property(flags TARGET ${target} PROPERTY INTERFACE_COMPILE_DEFINITIONS)
-
-  list(APPEND CFLAG_LIST)
-  foreach(flag ${flags})
-    # Replace each quote with a '\"' - format required for the GN arguments
-    string(REPLACE "\""  "\\\\\""  output_flag ${flag})
-    list(APPEND CFLAG_LIST "\"-D${output_flag}\"")
-  endforeach()
-  set(${output} ${CFLAG_LIST} PARENT_SCOPE)
+  set(${output} "'-D$<JOIN:$<TARGET_PROPERTY:${target},INTERFACE_COMPILE_DEFINITIONS>,'$<COMMA>'-D>'" PARENT_SCOPE)
 endfunction()
 
 # Get compile options of build for specific language


### PR DESCRIPTION
- Delay resolution of include and defines to build time. This allows the population of all the dependencies after the configuration has been run.
- Improve readability of args.gn generated.
- Improve external project definitions:
   - Remove configuration to run it everytime
   - Add ninja files to byproducts to delete them when the project is cleaned
   - Update args.gn only if if it has changed
