### PR TITLE
[OIS] Improve choosing the crypto option in OIS build process

### DIFF
--- a/config/openiotsdk/CMakeLists.txt
+++ b/config/openiotsdk/CMakeLists.txt
@@ -201,14 +201,11 @@ chip_gn_arg_bool  ("chip_progress_logging"                CONFIG_CHIP_PROGRESS_L
 chip_gn_arg_bool  ("chip_automation_logging"              CONFIG_CHIP_AUTOMATION_LOGGING)
 chip_gn_arg_bool  ("chip_error_logging"                   CONFIG_CHIP_ERROR_LOGGING)
 chip_gn_arg_bool  ("chip_openiotsdk_use_psa_ps"           CONFIG_CHIP_OPEN_IOT_SDK_USE_PSA_PS)
+chip_gn_arg_string("chip_crypto"                          "${CONFIG_CHIP_CRYPTO}")
 if (TARGET cmsis-rtos-api)
     chip_gn_arg_string("target_os"                        "cmsis-rtos")
 endif()
 chip_gn_arg_string("optimize_debug_level"                 "s")
-
-if (CONFIG_CHIP_CRYPTO_PSA)
-    chip_gn_arg_string("chip_crypto" "psa")
-endif()
 
 file(GENERATE OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/args.tmp" CONTENT ${CHIP_GN_ARGS})
 

--- a/config/openiotsdk/chip-gn/args.gni
+++ b/config/openiotsdk/chip-gn/args.gni
@@ -30,7 +30,6 @@ chip_system_config_use_lwip = true
 lwip_platform = "external"
 chip_system_config_use_sockets = false
 
-chip_crypto = "mbedtls"
 chip_external_mbedtls = true
 
 custom_toolchain = "${chip_root}/config/openiotsdk/chip-gn/toolchain:openiotsdk"

--- a/config/openiotsdk/cmake/chip.cmake
+++ b/config/openiotsdk/cmake/chip.cmake
@@ -33,6 +33,8 @@ set(CONFIG_CHIP_ERROR_LOGGING YES CACHE BOOL "Enable logging at error level")
 
 set(CONFIG_CHIP_OPEN_IOT_SDK_USE_PSA_PS NO CACHE BOOL "Enable using PSA Protected Storage")
 
+set(CONFIG_CHIP_CRYPTO "mbedtls" CACHE STRING "Matter crypto type. Mbedtls as default")
+
 if(CONFIG_CHIP_OPEN_IOT_SDK_USE_PSA_PS AND NOT TFM_SUPPORT)
     message( FATAL_ERROR "You can not use PSA Protected Storage without TF-M support" )
 endif()

--- a/scripts/examples/openiotsdk_example.sh
+++ b/scripts/examples/openiotsdk_example.sh
@@ -39,6 +39,7 @@ EXAMPLE_TEST_PATH="$CHIP_ROOT/src/test_driver/openiotsdk/integration-tests"
 TELNET_TERMINAL_PORT=5000
 FAILED_TESTS=0
 FVP_NETWORK="user"
+CRYPTO_TYPE="mbedtls"
 
 readarray -t TEST_NAMES <"$CHIP_ROOT"/src/test_driver/openiotsdk/unit-tests/testnames.txt
 
@@ -54,7 +55,7 @@ Options:
     -s,--scratch                       Remove build directory at all before building
     -C,--command    <command>          Action to execute <build-run | run | test | build - default>
     -d,--debug      <debug_enable>     Build in debug mode <true | false - default>
-    -a,--algorithm  <crypto algorithm) Select crypto algorithm <mbedtls - default | psa>
+    -a,--algorithm  <crypto algorithm) Select crypto algorithm <psa | mbedtls - default>
     -p,--path       <build_path>       Build path <build_path - default is example_dir/build>
     -n,--network    <network_name>     FVP network interface name <network_name - default is "user" which means user network mode>
 
@@ -105,9 +106,7 @@ function build_with_cmake() {
         BUILD_OPTIONS+=(-DCMAKE_BUILD_TYPE=Debug)
     fi
 
-    if [[ $CRYPTO == "psa" ]]; then
-        BUILD_OPTIONS+=(-DCONFIG_CHIP_CRYPTO_PSA=true)
-    fi
+    BUILD_OPTIONS+=(-DCONFIG_CHIP_CRYPTO="$CRYPTO_TYPE")
 
     # Remove old artifacts to force linking
     rm -rf "$BUILD_PATH/chip-"*
@@ -268,7 +267,7 @@ while :; do
             shift 2
             ;;
         -a | --algorithm)
-            CRYPTO=$2
+            CRYPTO_TYPE=$2
             shift 2
             ;;
         -p | --path)
@@ -334,6 +333,15 @@ case "$COMMAND" in
     build | run | test | build-run) ;;
     *)
         echo "Wrong command definition"
+        show_usage
+        exit 2
+        ;;
+esac
+
+case "$CRYPTO_TYPE" in
+    psa | mbedtls) ;;
+    *)
+        echo "Wrong crypto type definition"
         show_usage
         exit 2
         ;;


### PR DESCRIPTION
Directly pass crypto type to Cmake and GN build steps. Set default crypto value on both build script and the Cmake level.



