### PR TITLE
[OIS] Set of improvements for CI performance

### DIFF
--- a/.github/workflows/examples-openiotsdk.yaml
+++ b/.github/workflows/examples-openiotsdk.yaml
@@ -113,13 +113,13 @@ jobs:
               run: |
                   scripts/examples/openiotsdk_example.sh unit-tests
 
-            - name: Test shell example
+            - name: "Test: shell example"
               if: steps.build_shell.outcome == 'success'
               timeout-minutes: 5
               run: |
                   scripts/examples/openiotsdk_example.sh -C test shell
 
-            - name: Test lock-app example
+            - name: "Test: lock-app example"
               if: steps.build_lock_app.outcome == 'success'
               timeout-minutes: 5
               run: |
@@ -127,8 +127,8 @@ jobs:
                   scripts/run_in_ns.sh ${TEST_NETWORK_NAME}ns scripts/examples/openiotsdk_example.sh -C test -n ${TEST_NETWORK_NAME}tap lock-app
                   scripts/setup/openiotsdk/network_setup.sh -n $TEST_NETWORK_NAME down
             
-            - name: Run unit tests
+            - name: "Test: unit-tests"
               if: steps.build_unit_tests.outcome == 'success' && github.event_name == 'pull_request'
               timeout-minutes: 90
               run: |
-                  scripts/examples/openiotsdk_example.sh -C run unit-tests
+                  scripts/examples/openiotsdk_example.sh -C test unit-tests

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -335,6 +335,21 @@
             }
         },
         {
+            "label": "Test Open IoT SDK unit-tests",
+            "type": "shell",
+            "command": "scripts/examples/openiotsdk_example.sh",
+            "args": ["-Ctest", "unit-tests", "${input:openiotsdkUnitTest}"],
+            "group": "test",
+            "problemMatcher": {
+                "pattern": {
+                    "regexp": "^(.*):(\\d+):(\\d+):\\s+(warning|error):\\s+(.*)$",
+                    "file": 1,
+                    "line": 2,
+                    "message": 5
+                }
+            }
+        },
+        {
             "label": "Debug Open IoT SDK example",
             "type": "shell",
             "command": "scripts/run_in_ns.sh",
@@ -451,7 +466,6 @@
             "id": "openiotsdkUnitTest",
             "description": "What unit test do you want to use?",
             "options": [
-                "all",
                 "accesstest",
                 "AppTests",
                 "ASN1Tests",
@@ -478,7 +492,7 @@
                 "TransportLayerTests",
                 "UserDirectedCommissioningTests"
             ],
-            "default": "all"
+            "default": "accesstest"
         },
         {
             "type": "promptString",

--- a/examples/lock-app/openiotsdk/main/main_ns.cpp
+++ b/examples/lock-app/openiotsdk/main/main_ns.cpp
@@ -24,6 +24,8 @@
 
 static void app_thread(void * argument)
 {
+    ChipLogProgress(NotSpecified, "Open IoT SDK lock-app example application start");
+
     if (openiotsdk_network_init(true))
     {
         ChipLogError(NotSpecified, "Network initialization failed");
@@ -52,8 +54,6 @@ exit:
 
 int main()
 {
-    ChipLogProgress(NotSpecified, "Open IoT SDK lock-app example application start");
-
     if (openiotsdk_platform_init())
     {
         ChipLogError(NotSpecified, "Open IoT SDK platform initialization failed");

--- a/examples/platform/openiotsdk/app/openiotsdk_platform.cpp
+++ b/examples/platform/openiotsdk/app/openiotsdk_platform.cpp
@@ -25,6 +25,7 @@
 #include "openiotsdk_platform.h"
 
 #include "cmsis_os2.h"
+#include "hal/serial_api.h"
 #include "iotsdk/ip_network_api.h"
 #include "mbedtls/platform.h"
 
@@ -60,6 +61,10 @@ constexpr EndpointId kNetworkCommissioningEndpointSecondary = 0xFFFE;
 #define ALL_EVENTS_FLAGS (NETWORK_UP_FLAG | NETWORK_DOWN_FLAG)
 
 #define EVENT_TIMEOUT 5000
+
+// Consider reducing the baudrate if the serial is used as input and characters are lost
+extern "C" mdh_serial_t * get_example_serial();
+#define SERIAL_BAUDRATE 115200
 
 static osEventFlagsId_t event_flags_id;
 
@@ -171,6 +176,8 @@ int openiotsdk_platform_init(void)
 {
     int ret;
     osKernelState_t state;
+
+    mdh_serial_set_baud(get_example_serial(), SERIAL_BAUDRATE);
 
     ret = mbedtls_platform_setup(NULL);
     if (ret)

--- a/examples/shell/openiotsdk/main/main_ns.cpp
+++ b/examples/shell/openiotsdk/main/main_ns.cpp
@@ -33,6 +33,8 @@ static void app_thread(void * argument)
 {
     int ret;
 
+    ChipLogProgress(Shell, "Open IoT SDK shell example application start");
+
     if (openiotsdk_network_init(true))
     {
         ChipLogError(Shell, "Network initialization failed");
@@ -59,8 +61,6 @@ exit:
 
 int main()
 {
-    ChipLogProgress(Shell, "Open IoT SDK shell example application start");
-
     if (openiotsdk_platform_init())
     {
         ChipLogError(Shell, "Open IoT SDK platform initialization failed");

--- a/scripts/examples/openiotsdk_example.sh
+++ b/scripts/examples/openiotsdk_example.sh
@@ -18,7 +18,6 @@
 
 # Build and/or run Open IoT SDK examples.
 
-IS_TEST=0
 NAME="$(basename "$0")"
 HERE="$(dirname "$0")"
 CHIP_ROOT="$(realpath "$HERE"/../..)"
@@ -38,6 +37,7 @@ FVP_CONFIG_FILE="$OIS_CONFIG/fvp/cs300.conf"
 EXAMPLE_TEST_PATH="$CHIP_ROOT/src/test_driver/openiotsdk/integration-tests"
 TELNET_TERMINAL_PORT=5000
 FAILED_TESTS=0
+IS_UNIT_TEST=0
 FVP_NETWORK="user"
 
 readarray -t TEST_NAMES <"$CHIP_ROOT"/src/test_driver/openiotsdk/unit-tests/testnames.txt
@@ -62,15 +62,13 @@ Examples:
     lock-app
     unit-tests
 
-You can run individual test suites of unit tests by using their names [test_name] with the run command:
+You run or test individual test suites of unit tests by using their names [test_name] with the specified command:
 
 EOF
     cat "$CHIP_ROOT"/src/test_driver/openiotsdk/unit-tests/testnames.txt
     echo ""
     cat <<EOF
-Or you can use all tests suites with <all> parameter as [test_name]
-
-The "test" command can be used for all supported examples expect the unit-tests.
+Use test command without a specific test name, runs all supported unit tests.
 
 EOF
 }
@@ -132,12 +130,6 @@ function run_fvp() {
         exit 1
     fi
 
-    if [[ $IS_TEST -eq 0 ]]; then
-        EXAMPLE_EXE_PATH="$BUILD_PATH/chip-openiotsdk-$EXAMPLE-example.elf"
-    else
-        EXAMPLE_EXE_PATH="$BUILD_PATH/$EXAMPLE.elf"
-    fi
-
     # Check if executable file exists
     if ! [ -f "$EXAMPLE_EXE_PATH" ]; then
         echo "Error: $EXAMPLE_EXE_PATH does not exist." >&2
@@ -159,39 +151,20 @@ function run_fvp() {
 
     echo "Running $EXAMPLE_EXE_PATH with options: ${RUN_OPTIONS[@]}"
 
+    # Run the FVP
     "$FVP_BIN" "${RUN_OPTIONS[@]}" -f "$FVP_CONFIG_FILE" --application "$EXAMPLE_EXE_PATH" >/dev/null 2>&1 &
     FVP_PID=$!
     sleep 1
+    # Connect FVP via telnet client
+    telnet localhost "$TELNET_TERMINAL_PORT"
 
-    if [[ $IS_TEST -eq 1 ]]; then
-        set +e
-        expect <<EOF
-        set timeout 1800
-        set retcode -1
-        spawn telnet localhost ${TELNET_TERMINAL_PORT}
-        expect -re {Test status: (-?\d+)} {
-            set retcode \$expect_out(1,string)
-        }
-        expect "Open IoT SDK unit-tests completed"
-        set retcode [expr -1*\$retcode]
-        exit \$retcode
-EOF
-        RETCODE=$?
-        FAILED_TESTS=$(expr "$FAILED_TESTS" + "$RETCODE")
-        echo "$(jq '. += {($testname): {failed: $result}}' --arg testname "$EXAMPLE" --arg result "$RETCODE" "$EXAMPLE_PATH"/test_report.json)" >"$EXAMPLE_PATH"/test_report.json
-    else
-        telnet localhost "$TELNET_TERMINAL_PORT"
-    fi
-
-    # stop the fvp
-    kill -9 "$FVP_PID" || true
-    set -e
+    # Stop the FVP
+    kill -9 "$FVP_PID"
     sleep 1
 }
 
 function run_test() {
 
-    EXAMPLE_EXE_PATH="$BUILD_PATH/chip-openiotsdk-$EXAMPLE-example.elf"
     # Check if executable file exists
     if ! [ -f "$EXAMPLE_EXE_PATH" ]; then
         echo "Error: $EXAMPLE_EXE_PATH does not exist." >&2
@@ -219,19 +192,19 @@ function run_test() {
         TEST_OPTIONS+=(--networkInterface="$FVP_NETWORK")
     fi
 
-    if [[ -f $EXAMPLE_TEST_PATH/$EXAMPLE/test_report.json ]]; then
-        rm -rf "$EXAMPLE_TEST_PATH/$EXAMPLE"/test_report.json
+    if [[ -f $EXAMPLE_TEST_PATH/test_report_$EXAMPLE.json ]]; then
+        rm -rf "$EXAMPLE_TEST_PATH/test_report_$EXAMPLE".json
     fi
 
     set +e
-    pytest --json-report --json-report-summary --json-report-file="$EXAMPLE_TEST_PATH/$EXAMPLE"/test_report.json --binaryPath="$EXAMPLE_EXE_PATH" --fvp="$FVP_BIN" --fvpConfig="$FVP_CONFIG_FILE" "${TEST_OPTIONS[@]}" "$EXAMPLE_TEST_PATH/$EXAMPLE"/test_app.py
+    pytest --json-report --json-report-summary --json-report-file="$EXAMPLE_TEST_PATH"/test_report_"$EXAMPLE".json --binaryPath="$EXAMPLE_EXE_PATH" --fvp="$FVP_BIN" --fvpConfig="$FVP_CONFIG_FILE" "${TEST_OPTIONS[@]}" "$EXAMPLE_TEST_PATH"/test_app.py
     set -e
 
-    if [[ ! -f $EXAMPLE_TEST_PATH/$EXAMPLE/test_report.json ]]; then
+    if [[ ! -f $EXAMPLE_TEST_PATH/test_report_$EXAMPLE.json ]]; then
         exit 1
     else
-        if [[ $(jq '.summary | has("failed")' $EXAMPLE_TEST_PATH/$EXAMPLE/test_report.json) == true ]]; then
-            FAILED_TESTS=$(jq '.summary.failed' "$EXAMPLE_TEST_PATH/$EXAMPLE"/test_report.json)
+        if [[ $(jq '.summary | has("failed")' $EXAMPLE_TEST_PATH/test_report_$EXAMPLE.json) == true ]]; then
+            FAILED_TESTS=$((FAILED_TESTS + $(jq '.summary.failed' "$EXAMPLE_TEST_PATH"/test_report_"$EXAMPLE".json)))
         fi
     fi
 }
@@ -300,16 +273,20 @@ case "$1" in
         ;;
 esac
 
+case "$COMMAND" in
+    build | run | test | build-run) ;;
+    *)
+        echo "Wrong command definition"
+        show_usage
+        exit 2
+        ;;
+esac
+
 if [[ "$EXAMPLE" == "unit-tests" ]]; then
     if [ ! -z "$2" ]; then
         if [[ " ${TEST_NAMES[*]} " =~ " $2 " ]]; then
-            if [[ "$COMMAND" != *"run"* ]]; then
-                echo "Test suites can only accept --command run"
-                show_usage
-                exit 2
-            fi
             EXAMPLE=$2
-            echo "Run specific unit test $EXAMPLE"
+            echo "Use specific unit test $EXAMPLE"
         elif [[ "$2" == "all" ]]; then
             echo "Use all unit tests"
         else
@@ -320,32 +297,24 @@ if [[ "$EXAMPLE" == "unit-tests" ]]; then
     else
         echo "Use all unit tests"
     fi
-    IS_TEST=1
+    EXAMPLE_PATH="$CHIP_ROOT/src/test_driver/openiotsdk/unit-tests"
+    IS_UNIT_TEST=1
+else
+    EXAMPLE_PATH="$CHIP_ROOT/examples/$EXAMPLE/openiotsdk"
 fi
-
-case "$COMMAND" in
-    build | run | test | build-run) ;;
-    *)
-        echo "Wrong command definition"
-        show_usage
-        exit 2
-        ;;
-esac
 
 TOOLCHAIN_PATH="toolchains/toolchain-$TOOLCHAIN.cmake"
 
-if [[ $IS_TEST -eq 0 ]]; then
-    EXAMPLE_PATH="$CHIP_ROOT/examples/$EXAMPLE/openiotsdk"
-else
-    EXAMPLE_PATH="$CHIP_ROOT/src/test_driver/openiotsdk/unit-tests"
-    if [[ -f $EXAMPLE_PATH/test_report.json ]]; then
-        rm -rf "$EXAMPLE_PATH"/test_report.json
-    fi
-    echo "{}" >"$EXAMPLE_PATH"/test_report.json
-fi
-
 if [ -z "$BUILD_PATH" ]; then
     BUILD_PATH="$EXAMPLE_PATH/build"
+fi
+
+if [[ $IS_UNIT_TEST -eq 0 ]]; then
+    EXAMPLE_EXE_PATH="$BUILD_PATH/chip-openiotsdk-$EXAMPLE-example.elf"
+    EXAMPLE_TEST_PATH+="/$EXAMPLE"
+else
+    EXAMPLE_EXE_PATH="$BUILD_PATH/$EXAMPLE.elf"
+    EXAMPLE_TEST_PATH+="/unit-tests"
 fi
 
 if [[ "$COMMAND" == *"build"* ]]; then
@@ -353,21 +322,10 @@ if [[ "$COMMAND" == *"build"* ]]; then
 fi
 
 if [[ "$COMMAND" == *"run"* ]]; then
-    # If user wants to run unit-tests we need to loop through all test names
     if [[ "$EXAMPLE" == "unit-tests" ]]; then
-        if "$DEBUG"; then
-            echo "You have to specify the test suites to run in debug mode"
-            show_usage
-            exit 2
-        else
-            for NAME in "${TEST_NAMES[@]}"; do
-                EXAMPLE=$NAME
-                echo "$EXAMPLE_PATH"
-                echo "Run specific unit test $EXAMPLE"
-                run_fvp
-            done
-            echo "Failed tests total: $FAILED_TESTS"
-        fi
+        echo "You have to specify the test suites to run"
+        show_usage
+        exit 2
     else
         run_fvp
     fi
@@ -375,15 +333,16 @@ fi
 
 if [[ "$COMMAND" == *"test"* ]]; then
     if [[ "$EXAMPLE" == "unit-tests" ]]; then
-        echo "The test command can not be applied to the unit-tests example"
-        show_usage
-        exit 2
+        for NAME in "${TEST_NAMES[@]}"; do
+            EXAMPLE=$NAME
+            EXAMPLE_EXE_PATH="$BUILD_PATH/$EXAMPLE.elf"
+            echo "Test specific unit test $EXAMPLE"
+            run_test
+        done
+
     else
-        IS_TEST=1
         run_test
     fi
-fi
-
-if [[ $IS_TEST -eq 1 ]]; then
+    echo "Failed tests total: $FAILED_TESTS"
     exit "$FAILED_TESTS"
 fi

--- a/scripts/examples/openiotsdk_example.sh
+++ b/scripts/examples/openiotsdk_example.sh
@@ -102,6 +102,8 @@ function build_with_cmake() {
     BUILD_OPTIONS=(-DCMAKE_SYSTEM_PROCESSOR=cortex-m55)
     if "$DEBUG"; then
         BUILD_OPTIONS+=(-DCMAKE_BUILD_TYPE=Debug)
+    else
+        BUILD_OPTIONS+=(-DCMAKE_BUILD_TYPE=Release)
     fi
 
     # Remove old artifacts to force linking

--- a/src/inet/tests/TestInetAddress.cpp
+++ b/src/inet/tests/TestInetAddress.cpp
@@ -1009,7 +1009,7 @@ void CheckToIPv6(nlTestSuite * inSuite, void * inContext)
         SetupIPAddress(test_addr, lCurrent);
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
-        ip6_addr_t ip_addr_1, ip_addr_2;
+        ip6_addr_t ip_addr_1 = { 0 }, ip_addr_2 = { 0 };
         memcpy(ip_addr_1.addr, addr, sizeof(addr));
 #if LWIP_IPV6_SCOPES
         ip_addr_1.zone = 0;
@@ -1143,7 +1143,7 @@ void CheckToIPv4(nlTestSuite * inSuite, void * inContext)
         SetupIPAddress(test_addr, lCurrent);
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
-        ip4_addr_t ip_addr_1, ip_addr_2;
+        ip4_addr_t ip_addr_1 = { 0 }, ip_addr_2 = { 0 };
 
         ip_addr_1.addr = htonl(lCurrent->mAddr.mAddrQuartets[3]);
 #else

--- a/src/test_driver/openiotsdk/integration-tests/.gitignore
+++ b/src/test_driver/openiotsdk/integration-tests/.gitignore
@@ -1,1 +1,1 @@
-/**/test_report.json
+/**/test_report*.json

--- a/src/test_driver/openiotsdk/integration-tests/common/device.py
+++ b/src/test_driver/openiotsdk/integration-tests/common/device.py
@@ -72,7 +72,7 @@ class Device:
             except queue.Empty:
                 return lines
 
-    def wait_for_output(self, search: str, timeout: float = 10, assert_timeout: bool = True) -> [str]:
+    def wait_for_output(self, search: str, timeout: float = 10, assert_timeout: bool = True, verbose: bool = False) -> [str]:
         """
         Wait for expected output response
         :param search: Expected response string
@@ -109,7 +109,7 @@ class Device:
                     else:
                         log.warning(timeout_error_msg)
                         return []
-                if now - last > 1:
+                if verbose and (now - last > 1):
                     log.info('{}: Waiting for "{}" string... Timeout in {:.0f} s'.format(self.name, search,
                                                                                          abs(now - start - timeout)))
 

--- a/src/test_driver/openiotsdk/integration-tests/common/telnet_connection.py
+++ b/src/test_driver/openiotsdk/integration-tests/common/telnet_connection.py
@@ -115,6 +115,12 @@ class TelnetConnection:
         self.telnet.close()
         self.is_open = False
 
+    def set_port(self, port):
+        """
+        set port number of telnet connection
+        """
+        self.port = port
+
     def get_port(self):
         """
         Get port number of telnet connection

--- a/src/test_driver/openiotsdk/integration-tests/common/utils.py
+++ b/src/test_driver/openiotsdk/integration-tests/common/utils.py
@@ -79,9 +79,10 @@ def discover_device(devCtrl, setupPayload):
     return res[0]
 
 
-def connect_device(setupPayload, commissionableDevice, nodeId=None):
+def connect_device(devCtrl, setupPayload, commissionableDevice, nodeId=None):
     """
     Connect to Matter discovered device on network
+    :param devCtrl: device controller instance
     :param setupPayload: device setup payload
     :param commissionableDevice: CommissionableNode object with discovered device
     :param nodeId: device node ID
@@ -92,9 +93,13 @@ def connect_device(setupPayload, commissionableDevice, nodeId=None):
 
     pincode = int(setupPayload.attributes['SetUpPINCode'])
     try:
-        commissionableDevice.Commission(nodeId, pincode)
+        res = devCtrl.CommissionOnNetwork(
+            nodeId, pincode, filterType=discovery.FilterType.INSTANCE_NAME, filter=commissionableDevice.instanceName)
     except exceptions.ChipStackError as ex:
         log.error("Commission discovered device failed {}".format(str(ex)))
+        return None
+    if not res:
+        log.info("Commission discovered device failed")
         return None
     return nodeId
 

--- a/src/test_driver/openiotsdk/integration-tests/lock-app/test_app.py
+++ b/src/test_driver/openiotsdk/integration-tests/lock-app/test_app.py
@@ -57,11 +57,11 @@ def test_commissioning(device, controller):
     assert commissionable_device.productId == int(setupPayload.attributes['ProductID'])
     assert commissionable_device.addresses[0] != None
 
-    nodeId = connect_device(setupPayload, commissionable_device)
+    nodeId = connect_device(devCtrl, setupPayload, commissionable_device)
     assert nodeId != None
     log.info("Device {} connected".format(commissionable_device.addresses[0]))
 
-    ret = device.wait_for_output("Commissioning completed successfully", timeout=30)
+    ret = device.wait_for_output("Commissioning completed successfully")
     assert ret != None and len(ret) > 0
 
     assert disconnect_device(devCtrl, nodeId)
@@ -85,10 +85,10 @@ def test_lock_ctrl(device, controller):
     commissionable_device = discover_device(devCtrl, setupPayload)
     assert commissionable_device != None
 
-    nodeId = connect_device(setupPayload, commissionable_device)
+    nodeId = connect_device(devCtrl, setupPayload, commissionable_device)
     assert nodeId != None
 
-    ret = device.wait_for_output("Commissioning completed successfully", timeout=30)
+    ret = device.wait_for_output("Commissioning completed successfully")
     assert ret != None and len(ret) > 0
 
     err, res = send_zcl_command(

--- a/src/test_driver/openiotsdk/integration-tests/shell/test_app.py
+++ b/src/test_driver/openiotsdk/integration-tests/shell/test_app.py
@@ -1,17 +1,19 @@
-# Copyright (c) 2009-2021 Arm Limited
-# SPDX-License-Identifier: Apache-2.0
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+#    Copyright (c) 2022 Project CHIP Authors
+#    All rights reserved.
 #
-# http://www.apache.org/licenses/LICENSE-2.0
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
 #
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
 
 import pytest
 import re

--- a/src/test_driver/openiotsdk/integration-tests/unit-tests/test_app.py
+++ b/src/test_driver/openiotsdk/integration-tests/unit-tests/test_app.py
@@ -1,0 +1,52 @@
+#
+#    Copyright (c) 2022 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+import pytest
+import re
+from packaging import version
+from time import sleep
+
+from chip.setup_payload import SetupPayload
+from chip import exceptions
+import chip.native
+
+from common.utils import *
+
+import logging
+log = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="session")
+def binaryPath(request, rootDir):
+    if request.config.getoption('binaryPath'):
+        return request.config.getoption('binaryPath')
+    else:
+        assert False
+
+
+def test_unit_tests(device):
+    ret = device.wait_for_output("Open IoT SDK unit-tests start")
+    assert ret != None and len(ret) > 0
+    ret = device.wait_for_output("Open IoT SDK unit-tests run")
+    assert ret != None and len(ret) > 0
+
+    ret = device.wait_for_output("Test status:", 600)
+    # Get test status
+    test_status = ret[-1]
+    result = re.findall(r'\d+', test_status)
+    assert len(result) == 1
+    assert int(result[0]) == 0

--- a/src/test_driver/openiotsdk/unit-tests/.gitignore
+++ b/src/test_driver/openiotsdk/unit-tests/.gitignore
@@ -1,2 +1,1 @@
 build/
-test_report.json

--- a/src/test_driver/openiotsdk/unit-tests/main/main.cpp
+++ b/src/test_driver/openiotsdk/unit-tests/main/main.cpp
@@ -36,6 +36,8 @@ static void test_thread(void * argument)
     int status;
     CHIP_ERROR err;
 
+    ChipLogAutomation("Open IoT SDK unit-tests start");
+
     if (openiotsdk_network_init(true))
     {
         ChipLogAutomation("ERROR: Network initialization failed");
@@ -59,8 +61,6 @@ exit:
 
 int main()
 {
-    ChipLogAutomation("Open IoT SDK unit-tests start");
-
     if (openiotsdk_platform_init())
     {
         ChipLogAutomation("ERROR: Open IoT SDK platform initialization failed");


### PR DESCRIPTION
Improvements:
 - Build Matter examples in actual release mode. Set CMAKE_BUILD_TYPE to Release for non-debug mode. It also required fixing LwIP structure initialization in unit tests.
 - Increase output UART baud rate to 921600
 - Improve the commissioning function to return commission errors in integration tests.
 - Create unit-tests Python integration test that checks and controls time execution of OIS unit-tests.

Solved issue:
#31