### PR TITLE
psa: First drop of PSA into Matter

### DIFF
--- a/.github/workflows/examples-openiotsdk.yaml
+++ b/.github/workflows/examples-openiotsdk.yaml
@@ -47,7 +47,8 @@ jobs:
             fail-fast: false
             matrix:
                 socketAPI: ["iotsocket", "lwip"]
-                
+                cryptoBackend: ["psa", "mbedtls"]
+
         name: Open IoT SDK examples building
         timeout-minutes: 60
 
@@ -96,7 +97,7 @@ jobs:
               id: build_shell
               timeout-minutes: 10
               run: |
-                  scripts/examples/openiotsdk_example.sh -S ${{ matrix.socketAPI }} shell
+                  scripts/examples/openiotsdk_example.sh -S ${{ matrix.socketAPI }} -b ${{ matrix.cryptoBackend }} shell
                   .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
                     openiotsdk release shell \
                     examples/shell/openiotsdk/build/chip-openiotsdk-shell-example.elf \
@@ -106,7 +107,7 @@ jobs:
               id: build_lock_app
               timeout-minutes: 10
               run: |
-                  scripts/examples/openiotsdk_example.sh -S ${{ matrix.socketAPI }} lock-app
+                  scripts/examples/openiotsdk_example.sh -S ${{ matrix.socketAPI }} -b ${{ matrix.cryptoBackend }} lock-app
                   .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
                     openiotsdk release lock-app \
                     examples/lock-app/openiotsdk/build/chip-openiotsdk-lock-app-example.elf \
@@ -116,7 +117,7 @@ jobs:
               id: build_unit_tests
               timeout-minutes: 10
               run: |
-                  scripts/examples/openiotsdk_example.sh -S ${{ matrix.socketAPI }} unit-tests
+                  scripts/examples/openiotsdk_example.sh -S ${{ matrix.socketAPI }} -b ${{ matrix.cryptoBackend }} unit-tests
 
             - name: "Test: shell example"
               if: steps.build_shell.outcome == 'success'
@@ -131,7 +132,7 @@ jobs:
                   scripts/setup/openiotsdk/network_setup.sh -n $TEST_NETWORK_NAME up
                   scripts/run_in_ns.sh ${TEST_NETWORK_NAME}ns scripts/examples/openiotsdk_example.sh -C test -n ${TEST_NETWORK_NAME}tap lock-app
                   scripts/setup/openiotsdk/network_setup.sh -n $TEST_NETWORK_NAME down
-            
+
             - name: "Test: unit-tests"
               if: steps.build_unit_tests.outcome == 'success' && github.event_name == 'pull_request'
               timeout-minutes: 30

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -250,6 +250,7 @@
             "args": [
                 "-Cbuild",
                 "-d${input:openiotsdkDebugMode}",
+                "-b${input:openiotsdkCryptoBackend}",
                 "${input:openiotsdkExample}"
             ],
             "group": "build",
@@ -266,7 +267,12 @@
             "label": "Build Open IoT SDK unit-tests",
             "type": "shell",
             "command": "scripts/examples/openiotsdk_example.sh",
-            "args": ["-Cbuild", "-d${input:openiotsdkDebugMode}", "unit-tests"],
+            "args": [
+                "-Cbuild",
+                "-d${input:openiotsdkDebugMode}",
+                "-b${input:openiotsdkCryptoBackend}",
+                "unit-tests"
+            ],
             "group": "build",
             "problemMatcher": {
                 "pattern": {
@@ -453,6 +459,13 @@
             "description": "Do you want to use debug mode?",
             "options": ["false", "true"],
             "default": "false"
+        },
+        {
+            "type": "pickString",
+            "id": "openiotsdkCryptoBackend",
+            "description": "Which Crypto algorithm do you wish to use?",
+            "options": ["mbedtls", "psa"],
+            "default": "mbedtls"
         },
         {
             "type": "pickString",

--- a/config/openiotsdk/CMakeLists.txt
+++ b/config/openiotsdk/CMakeLists.txt
@@ -129,7 +129,7 @@ endif()
 # Set up CHIP project configuration file
 
 if (CONFIG_CHIP_PROJECT_CONFIG)
-    get_filename_component(CHIP_PROJECT_CONFIG 
+    get_filename_component(CHIP_PROJECT_CONFIG
         ${CONFIG_CHIP_PROJECT_CONFIG}
         REALPATH
         BASE_DIR ${CMAKE_SOURCE_DIR}
@@ -192,6 +192,7 @@ chip_gn_arg_bool  ("chip_automation_logging"              CONFIG_CHIP_AUTOMATION
 chip_gn_arg_bool  ("chip_error_logging"                   CONFIG_CHIP_ERROR_LOGGING)
 chip_gn_arg_bool  ("chip_openiotsdk_use_psa_ps"           CONFIG_CHIP_OPEN_IOT_SDK_USE_PSA_PS)
 chip_gn_arg_bool  ("chip_system_config_use_iot_socket"    CONFIG_CHIP_OPEN_IOT_SDK_USE_IOT_SOCKET)
+chip_gn_arg_string("chip_crypto"                          "${CONFIG_CHIP_CRYPTO}")
 if (TARGET cmsis-rtos-api)
     chip_gn_arg_string("target_os"                        "cmsis-rtos")
 endif()
@@ -224,7 +225,7 @@ ExternalProject_Add(
 )
 
 # ==============================================================================
-# Define 'openiotsdk-chip' target that exposes CHIP and Open IoT SDK 
+# Define 'openiotsdk-chip' target that exposes CHIP and Open IoT SDK
 # headers & libraries to the application
 # ==============================================================================
 add_library(openiotsdk-chip INTERFACE)

--- a/config/openiotsdk/chip-gn/args.gni
+++ b/config/openiotsdk/chip-gn/args.gni
@@ -30,7 +30,6 @@ chip_system_config_use_lwip = true
 lwip_platform = "external"
 chip_system_config_use_sockets = false
 
-chip_crypto = "mbedtls"
 chip_external_mbedtls = true
 
 custom_toolchain = "${chip_root}/config/openiotsdk/chip-gn/toolchain:openiotsdk"

--- a/config/openiotsdk/cmake/chip.cmake
+++ b/config/openiotsdk/cmake/chip.cmake
@@ -21,7 +21,7 @@
 
 get_filename_component(GEN_DIR ${CHIP_ROOT}/zzz_generated/ REALPATH)
 
-# Default CHIP build configuration 
+# Default CHIP build configuration
 set(CONFIG_CHIP_PROJECT_CONFIG "main/include/CHIPProjectConfig.h" CACHE STRING "")
 set(CONFIG_CHIP_LIB_TESTS NO CACHE BOOL "")
 set(CONFIG_CHIP_LIB_SHELL NO CACHE BOOL "")
@@ -34,6 +34,7 @@ set(CONFIG_CHIP_ERROR_LOGGING YES CACHE BOOL "Enable logging at error level")
 set(CONFIG_CHIP_OPEN_IOT_SDK_USE_PSA_PS NO CACHE BOOL "Enable using PSA Protected Storage")
 
 set(CONFIG_CHIP_OPEN_IOT_SDK_USE_IOT_SOCKET NO CACHE BOOL "Enable using IoT Socket API")
+set(CONFIG_CHIP_CRYPTO "mbedtls" CACHE STRING "Matter crypto backend. Mbedtls as default")
 
 if(CONFIG_CHIP_OPEN_IOT_SDK_USE_PSA_PS AND NOT TFM_SUPPORT)
     message( FATAL_ERROR "You can not use PSA Protected Storage without TF-M support" )
@@ -52,14 +53,20 @@ if(TFM_SUPPORT)
     endif()
 endif()
 
+if ("${CONFIG_CHIP_CRYPTO}" STREQUAL "psa")
+    target_compile_definitions(openiotsdk-chip
+        INTERFACE
+            CONFIG_CHIP_CRYPTO_PSA)
+endif()
+
 function(chip_add_data_model target model_name)
-    target_include_directories(${target} 
+    target_include_directories(${target}
         PUBLIC
             ${GEN_DIR}/app-common
             ${GEN_DIR}/${model_name}-app
     )
 
-    target_sources(${target} 
+    target_sources(${target}
         PUBLIC
             ${GEN_DIR}/${model_name}-app/zap-generated/IMClusterCommandHandler.cpp
     )

--- a/examples/platform/openiotsdk/app/openiotsdk_platform.cpp
+++ b/examples/platform/openiotsdk/app/openiotsdk_platform.cpp
@@ -29,6 +29,10 @@
 #include "iotsdk/ip_network_api.h"
 #include "mbedtls/platform.h"
 
+#ifdef CONFIG_CHIP_CRYPTO_PSA
+#include "psa/crypto.h"
+#endif
+
 #include <DeviceInfoProviderImpl.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/logging/CHIPLogging.h>
@@ -50,6 +54,10 @@
 #include "psa/update.h"
 #include "tfm_ns_interface.h"
 #endif // TFM_SUPPORT
+
+#if defined(CONFIG_CHIP_CRYPTO_PSA) && !defined(MBEDTLS_PSA_CRYPTO_C)
+#error "PSA Crypto must be enabled in Mbed TLS to support PSA Crypto backend"
+#endif
 
 using namespace ::chip;
 using namespace ::chip::Platform;
@@ -185,6 +193,15 @@ int openiotsdk_platform_init(void)
         ChipLogError(NotSpecified, "Mbed TLS platform initialization failed: %d", ret);
         return EXIT_FAILURE;
     }
+
+#ifdef CONFIG_CHIP_CRYPTO_PSA
+    ret = psa_crypto_init();
+    if (ret)
+    {
+        ChipLogError(NotSpecified, "PSA crypto initialization failed: %d", ret);
+        return EXIT_FAILURE;
+    }
+#endif
 
 #ifdef TFM_SUPPORT
     ret = tfm_ns_interface_init();

--- a/src/crypto/BUILD.gn
+++ b/src/crypto/BUILD.gn
@@ -119,9 +119,7 @@ if (chip_crypto == "openssl") {
     sources = [ "CHIPCryptoPALPSA.cpp" ]
     public_deps = [ ":public_headers" ]
 
-    external_mbedtls = current_os == "zephyr"
-
-    if (!external_mbedtls) {
+    if (!chip_external_mbedtls) {
       public_deps += [ "${mbedtls_root}:mbedtls" ]
     }
   }

--- a/src/crypto/crypto.gni
+++ b/src/crypto/crypto.gni
@@ -13,13 +13,10 @@
 # limitations under the License.
 
 declare_args() {
-  # Crypto implementation: mbedtls, openssl, tinycrypt, boringssl, platform.
+  # Crypto implementation: mbedtls, psa, openssl, tinycrypt, boringssl, platform.
   chip_crypto = ""
   chip_with_se05x = 0
 
-  # Compile mbedtls externally. Only used if chip_crypto == "mbedtls"
+  # Compile mbedtls externally.
   chip_external_mbedtls = false
 }
-
-assert(!chip_external_mbedtls || chip_crypto == "mbedtls",
-       "Use of external mbedtls requires the mbedtls crypto impl")

--- a/src/test_driver/openiotsdk/integration-tests/common/utils.py
+++ b/src/test_driver/openiotsdk/integration-tests/common/utils.py
@@ -41,7 +41,7 @@ def get_setup_payload(device):
     :param device: serial device instance
     :return: setup payload or None
     """
-    ret = device.wait_for_output("SetupQRCode")
+    ret = device.wait_for_output("SetupQRCode", timeout=15)
     if ret == None or len(ret) < 2:
         return None
 

--- a/src/test_driver/openiotsdk/integration-tests/lock-app/test_app.py
+++ b/src/test_driver/openiotsdk/integration-tests/lock-app/test_app.py
@@ -38,7 +38,7 @@ def binaryPath(request, rootDir):
 def test_smoke_test(device):
     ret = device.wait_for_output("Open IoT SDK lock-app example application start")
     assert ret != None and len(ret) > 0
-    ret = device.wait_for_output("Open IoT SDK lock-app example application run")
+    ret = device.wait_for_output("Open IoT SDK lock-app example application run", timeout=15)
     assert ret != None and len(ret) > 0
 
 


### PR DESCRIPTION
This PR brings PSA cryptography into the ARM-software version of Matter and builds with the SDK.

There is an update to the VSCode docker image to allow the SDK unit tests and examples to be built with PSA or mbedtls via the Tasks menus.

There is also an update to the CI workflow for the SDK examples to build and run the tests with both mbedtls and psa cryptographic algorithms. 