### PR TITLE
[OIS] Set of improvements for CI performance #2

### DIFF
--- a/.github/workflows/examples-openiotsdk.yaml
+++ b/.github/workflows/examples-openiotsdk.yaml
@@ -49,7 +49,7 @@ jobs:
                 socketAPI: ["iotsocket", "lwip"]
                 
         name: Open IoT SDK examples building
-        timeout-minutes: 140
+        timeout-minutes: 60
 
         needs: pre_job
 
@@ -134,6 +134,6 @@ jobs:
             
             - name: "Test: unit-tests"
               if: steps.build_unit_tests.outcome == 'success' && github.event_name == 'pull_request'
-              timeout-minutes: 90
+              timeout-minutes: 30
               run: |
                   scripts/examples/openiotsdk_example.sh -C test unit-tests

--- a/examples/platform/openiotsdk/app/openiotsdk_platform.cpp
+++ b/examples/platform/openiotsdk/app/openiotsdk_platform.cpp
@@ -66,7 +66,7 @@ constexpr EndpointId kNetworkCommissioningEndpointSecondary = 0xFFFE;
 // Consider reducing the baudrate if the serial is used as input and characters are lost
 extern "C" mdh_serial_t * get_example_serial();
 #ifndef IOT_SDK_APP_SERIAL_BAUDRATE
-#define IOT_SDK_APP_SERIAL_BAUDRATE 115200
+#define IOT_SDK_APP_SERIAL_BAUDRATE 921600
 #endif
 
 static osEventFlagsId_t event_flags_id;

--- a/examples/shell/openiotsdk/CMakeLists.txt
+++ b/examples/shell/openiotsdk/CMakeLists.txt
@@ -59,6 +59,11 @@ include(chip)
 
 add_subdirectory(${OPEN_IOT_SDK_EXAMPLE_COMMON}/app ./app_build)
 
+target_compile_definitions(openiotsdk-app
+    PRIVATE
+        IOT_SDK_APP_SERIAL_BAUDRATE=9600
+)
+
 target_include_directories(${APP_TARGET} 
     PRIVATE
         main/include

--- a/src/test_driver/openiotsdk/integration-tests/common/telnet_connection.py
+++ b/src/test_driver/openiotsdk/integration-tests/common/telnet_connection.py
@@ -34,6 +34,7 @@ class TelnetConnection:
         self.host = host
         self.port = port
         self.is_open = False
+        self.output_line = bytearray()
 
     def open(self):
         """
@@ -86,11 +87,15 @@ class TelnetConnection:
         if not self.is_open:
             return None
         try:
-            output = self.telnet.read_until(b"\n", 1)
-            return self.__formatline(output)
+            self.output_line.extend(self.telnet.read_until(b"\n", 1)) 
+            if b"\n" in self.output_line:
+                output = self.__formatline(self.output_line)
+                self.output_line.clear()
+                return output
         except Exception as e:
             log.error('Telnet read failed {}'.format(e))
             return None
+        return None
 
     def write(self, data):
         """

--- a/src/test_driver/openiotsdk/integration-tests/unit-tests/test_app.py
+++ b/src/test_driver/openiotsdk/integration-tests/unit-tests/test_app.py
@@ -42,7 +42,7 @@ def test_unit_tests(device):
     ret = device.wait_for_output("Open IoT SDK unit-tests start")
     assert ret != None and len(ret) > 0
 
-    ret = device.wait_for_output("Test status:", 600)
+    ret = device.wait_for_output("Test status:", 1200)
     # Get test status
     test_status = ret[-1]
     result = re.findall(r'\d+', test_status)

--- a/src/test_driver/openiotsdk/unit-tests/CMakeLists.txt
+++ b/src/test_driver/openiotsdk/unit-tests/CMakeLists.txt
@@ -66,13 +66,6 @@ foreach(TEST_NAME IN LISTS TEST_NAMES_FROM_FILE)
             main/main.cpp
     )
 
-    if (${TEST_NAME} STREQUAL "TestShell")
-        target_compile_definitions(openiotsdk-app
-            PRIVATE
-                IOT_SDK_APP_SERIAL_BAUDRATE=9600
-        )
-    endif()
-
     target_link_libraries(${TEST_NAME} 
         openiotsdk-app
     )


### PR DESCRIPTION
Improvements:
 - set maximum baudrate as default and adjust this to specific Matter example
 - remove the redundant `NDEBUG` setting in the config cmake 

Fixing:
#32 