### PR TITLE
Tasks: Add socket option to tasks for unit tests/examples

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -251,6 +251,7 @@
                 "-Cbuild",
                 "-d${input:openiotsdkDebugMode}",
                 "-b${input:openiotsdkCryptoBackend}",
+                "-S${input:openiotsdkSocketAPI}",
                 "${input:openiotsdkExample}"
             ],
             "group": "build",
@@ -271,6 +272,7 @@
                 "-Cbuild",
                 "-d${input:openiotsdkDebugMode}",
                 "-b${input:openiotsdkCryptoBackend}",
+                "-S${input:openiotsdkSocketAPI}",
                 "unit-tests"
             ],
             "group": "build",
@@ -466,6 +468,13 @@
             "description": "Which Crypto algorithm do you wish to use?",
             "options": ["mbedtls", "psa"],
             "default": "mbedtls"
+        },
+        {
+            "type": "pickString",
+            "id": "openiotsdkSocketAPI",
+            "description": "Which socket API do you wish to use?",
+            "options": ["iotsocket", "lwip"],
+            "default": "iotsocket"
         },
         {
             "type": "pickString",

--- a/docs/examples/openiotsdk_examples.md
+++ b/docs/examples/openiotsdk_examples.md
@@ -147,7 +147,13 @@ You build using a vscode task or call the script directly from the command line.
 ### Building using vscode task
 
 ```
-Command Palette (F1) => Run Task... => Build Open IoT SDK example => (debug on/off) => <example name>
+Command Palette (F1)
+=> Run Task...
+=> Build Open IoT SDK example
+=> Use debug mode (True/False)
+=> Choose crypto algorithm (mbedtls/psa)
+=> Choose socket API (iotsocket/lwip)
+=> <example name>
 ```
 
 This will call the scripts with the selected parameters.


### PR DESCRIPTION
This adds the option to select the socket type when building either the SDK unit tests or the examples via the tasks menus in VSCode. It allows selection of iotsocket or lwip, iotsocket being the default.

