### PR TITLE
[Internal] Add fork update CI workflow

### DIFF
--- a/.github/workflows/upstream-update.yaml
+++ b/.github/workflows/upstream-update.yaml
@@ -1,0 +1,43 @@
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Update with upstream repository
+on:
+    schedule:
+      - cron:  0 0 * * *
+      # scheduled at 00:00 every day
+    workflow_dispatch:
+
+jobs:
+    sync_with_upstream:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: Wandalen/wretry.action@v1.0.36
+              name: Checkout
+              with:
+                  action: actions/checkout@v3
+                  with: |
+                      token: ${{ secrets.WORKFLOW_TOKEN }}
+                      ref: master
+                      fetch-depth: 100
+                  attempt_limit: 3
+                  attempt_delay: 2000
+
+            - name: Update 
+              uses: imba-tjd/rebase-upstream-action@0.5
+              with:
+                upstream: https://github.com/project-chip/connectedhomeip
+                branch: master # the upstream branch that is rebased on
+                depth: 100 # number of commits to fetch
+                push: true # do the force push if rebase success


### PR DESCRIPTION
Create the update with the upstream repository CI workflow. This allows for cyclic synchronization of our master branch with the upstream repository. The sync is scheduled at 00:00 every day or can be triggered manually.

Used Gtihub action: https://github.com/imba-tjd/rebase-upstream-action

The results are visible here: https://github.com/ARM-software/connectedhomeip/tree/master