### PR TITLE
Tools: Comment out default Fastmodels mount link

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,7 @@
     "mounts": [
         "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind",
         // Provide a path to your local FastModelsPortfolio_11.16
-        "source=/path/to/FastModelsPortfolio_11.16,target=/opt/FastModelsPortfolio_11.16,type=bind,consistency=cached"
+        //"source=/path/to/FastModelsPortfolio_11.16,target=/opt/FastModelsPortfolio_11.16,type=bind,consistency=cached"
     ],
     "build": {
         "dockerfile": "Dockerfile",

--- a/scripts/examples/openiotsdk_example.sh
+++ b/scripts/examples/openiotsdk_example.sh
@@ -142,6 +142,12 @@ function run_fvp() {
         exit 1
     fi
 
+    # Check if gdb plugin exist file exists
+    if ! [ -f "$GDB_PLUGIN" ]; then
+        echo "Error: $GDB_PLUGIN does not exist. Ensure Fast Model extensions are mounted." >&2
+        exit 1
+    fi
+
     RUN_OPTIONS=(-C mps3_board.telnetterminal0.start_port="$TELNET_TERMINAL_PORT")
     RUN_OPTIONS+=(--quantum=25)
 


### PR DESCRIPTION
There is a default fast models mount link in the devcontainer which doesn't work out of the box and is there primarily as an example of how to set it up. This can cause the devcontainer to fail to load properly without errors. This commit comments out the link.
