### PR TITLE
Make the devcontainer image build a standalone script

### DIFF
--- a/.devcontainer/build.sh
+++ b/.devcontainer/build.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+#
+#    Copyright (c) 2023 Project CHIP Authors
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+HERE="$(dirname "$0")"
+BUILD_VERSION="0.6.35"
+IMAGE_TAG="matter-dev-environment:local"
+USER_UID=$UID
+
+function show_usage {
+    cat <<EOF
+Usage: $0
+
+Build vscode dev environment docker image.
+
+Options:
+    -h,--help        Show this help
+    -t,--tag         Image tag
+    -u,--uid         User UIDa
+    -v,--version     Build version
+EOF
+}
+
+SHORT=t:,u:,h:,v
+LONG=tag:,uid:,help:,version
+OPTS=$(getopt -n build --options $SHORT --longoptions $LONG -- "$@")
+
+eval set -- "$OPTS"
+
+while :; do
+    case "$1" in
+    -h | --help)
+        show_usage
+        exit 0
+        ;;
+    -t | --tag)
+        IMAGE_TAG=$2
+        shift 2
+        ;;
+    -u | --uid)
+        USER_UID=$2
+        shift 2
+        ;;
+    -v | --version)
+        BUILD_VERSION=$2
+        shift 2
+        ;;
+    --)
+        shift
+        break
+        ;;
+    *)
+        echo "Unexpected option: $1"
+        show_usage
+        exit 2
+        ;;
+    esac
+done
+
+if [ $USER_UID = "0" ]; then
+    USER_UID=1000
+fi
+
+docker build \
+    -t $IMAGE_TAG \
+    --pull \
+    --build-arg USER_UID=$USER_UID \
+    --build-arg BUILD_VERSION=$BUILD_VERSION \
+    --network=host \
+    $HERE

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,12 +15,8 @@
         // Provide a path to your local FastModelsPortfolio_11.16
         //"source=/path/to/FastModelsPortfolio_11.16,target=/opt/FastModelsPortfolio_11.16,type=bind,consistency=cached"
     ],
-    "build": {
-        "dockerfile": "Dockerfile",
-        "args": {
-            "BUILD_VERSION": "0.6.35"
-        }
-    },
+    "image": "matter-dev-environment:local",
+    "initializeCommand": ".devcontainer/build.sh",
     "remoteUser": "vscode",
     // Add the IDs of extensions you want installed when the container is created in the array below.
     "extensions": [


### PR DESCRIPTION
Issue :
Building the vsc dev container fail on my end. I have issues with the dns setup most likely as apt get can't resolve any address. I could potentially fix it locally by creating some dns redirection for my docker, but I'd be surprised if I'm the only one with this issue. I believe this should be fixed in the build script to make it easier to use.

Solution :
We need to set --net=host for the image creation. To do that we make the container build script a standalone script, allowing us a greater control on the build parameters

