### PR TITLE
Update PSA serialize and deserialize functions

### DIFF
--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -548,7 +548,11 @@ void Server::ResumeSubscriptions()
 Credentials::IgnoreCertificateValidityPeriodPolicy Server::sDefaultCertValidityPolicy;
 
 KvsPersistentStorageDelegate CommonCaseDeviceServerInitParams::sKvsPersistenStorageDelegate;
+#if CHIP_CRYPTO_PSA
+Crypto::PSAOperationalKeystore CommonCaseDeviceServerInitParams::sPersistentStorageOperationalKeystore;
+#else
 PersistentStorageOperationalKeystore CommonCaseDeviceServerInitParams::sPersistentStorageOperationalKeystore;
+#endif
 Credentials::PersistentStorageOpCertStore CommonCaseDeviceServerInitParams::sPersistentStorageOpCertStore;
 Credentials::GroupDataProviderImpl CommonCaseDeviceServerInitParams::sGroupDataProvider;
 #if CHIP_CONFIG_ENABLE_SESSION_RESUMPTION

--- a/src/app/server/Server.h
+++ b/src/app/server/Server.h
@@ -40,7 +40,11 @@
 #include <credentials/PersistentStorageOpCertStore.h>
 #include <crypto/DefaultSessionKeystore.h>
 #include <crypto/OperationalKeystore.h>
+#if CHIP_CRYPTO_PSA
+#include <crypto/PSAOperationalKeystore.h>
+#else
 #include <crypto/PersistentStorageOperationalKeystore.h>
+#endif
 #include <inet/InetConfig.h>
 #include <lib/core/CHIPConfig.h>
 #include <lib/support/SafeInt.h>
@@ -202,7 +206,11 @@ struct CommonCaseDeviceServerInitParams : public ServerInitParams
         {
             // WARNING: PersistentStorageOperationalKeystore::Finish() is never called. It's fine for
             //          for examples and for now.
+#if !CHIP_CRYPTO_PSA
             ReturnErrorOnFailure(sPersistentStorageOperationalKeystore.Init(this->persistentStorageDelegate));
+#else
+            // Note: PSA Operational keystore does not require initialization
+#endif
             this->operationalKeystore = &sPersistentStorageOperationalKeystore;
         }
 
@@ -251,7 +259,11 @@ struct CommonCaseDeviceServerInitParams : public ServerInitParams
 
 private:
     static KvsPersistentStorageDelegate sKvsPersistenStorageDelegate;
+#if CHIP_CRYPTO_PSA
+    static Crypto::PSAOperationalKeystore sPersistentStorageOperationalKeystore;
+#else
     static PersistentStorageOperationalKeystore sPersistentStorageOperationalKeystore;
+#endif
     static Credentials::PersistentStorageOpCertStore sPersistentStorageOpCertStore;
     static Credentials::GroupDataProviderImpl sGroupDataProvider;
 #if CHIP_CONFIG_ENABLE_SESSION_RESUMPTION

--- a/src/app/tests/integration/common.cpp
+++ b/src/app/tests/integration/common.cpp
@@ -26,7 +26,11 @@
 
 #include <app/tests/integration/common.h>
 #include <credentials/PersistentStorageOpCertStore.h>
+#if CHIP_CRYPTO_PSA
+#include <crypto/PSAOperationalKeystore.h>
+#else
 #include <crypto/PersistentStorageOperationalKeystore.h>
+#endif
 #include <lib/core/CHIPCore.h>
 #include <lib/core/TLVDebug.h>
 #include <lib/support/CodeUtils.h>
@@ -41,7 +45,11 @@ chip::SessionManager gSessionManager;
 chip::secure_channel::MessageCounterManager gMessageCounterManager;
 chip::SessionHolder gSession;
 chip::TestPersistentStorageDelegate gStorage;
+#if CHIP_CRYPTO_PSA
+chip::Crypto::PSAOperationalKeystore gOperationalKeystore;
+#else
 chip::PersistentStorageOperationalKeystore gOperationalKeystore;
+#endif
 chip::Credentials::PersistentStorageOpCertStore gOpCertStore;
 chip::Crypto::DefaultSessionKeystore gSessionKeystore;
 
@@ -64,8 +72,10 @@ void InitializeChip()
     err = gOpCertStore.Init(&gStorage);
     SuccessOrExit(err);
 
+#if !CHIP_CRYPTO_PSA
     err = gOperationalKeystore.Init(&gStorage);
     SuccessOrExit(err);
+#endif
 
     fabricTableInitParams.storage             = &gStorage;
     fabricTableInitParams.operationalKeystore = &gOperationalKeystore;
@@ -92,7 +102,9 @@ void ShutdownChip()
     gSessionManager.Shutdown();
 
     gFabricTable.Shutdown();
+#if !CHIP_CRYPTO_PSA
     gOperationalKeystore.Finish();
+#endif
     gOpCertStore.Finish();
 
     chip::DeviceLayer::PlatformMgr().Shutdown();

--- a/src/app/tests/suites/credentials/TestHarnessDACProvider.cpp
+++ b/src/app/tests/suites/credentials/TestHarnessDACProvider.cpp
@@ -176,16 +176,6 @@ bool ReadValue(Json::Value jsonValue)
     return false;
 }
 
-// TODO: This should be moved to a method of P256Keypair
-CHIP_ERROR LoadKeypairFromRaw(ByteSpan private_key, ByteSpan public_key, Crypto::P256Keypair & keypair)
-{
-    Crypto::P256SerializedKeypair serialized_keypair;
-    ReturnErrorOnFailure(serialized_keypair.SetLength(private_key.size() + public_key.size()));
-    memcpy(serialized_keypair.Bytes(), public_key.data(), public_key.size());
-    memcpy(serialized_keypair.Bytes() + public_key.size(), private_key.data(), private_key.size());
-    return keypair.Deserialize(serialized_keypair);
-}
-
 } // namespace
 
 TestHarnessDACProvider::TestHarnessDACProvider()
@@ -321,7 +311,8 @@ CHIP_ERROR TestHarnessDACProvider::SignWithDeviceAttestationKey(const ByteSpan &
 
     // In a non-exemplary implementation, the public key is not needed here. It is used here merely because
     // Crypto::P256Keypair is only (currently) constructable from raw keys if both private/public keys are present.
-    ReturnErrorOnFailure(LoadKeypairFromRaw(mDacPrivateKey, mDacPublicKey, keypair));
+    ReturnErrorOnFailure(keypair.ImportRawKeypair(mDacPrivateKey, mDacPublicKey));
+
     ReturnErrorOnFailure(keypair.ECDSA_sign_msg(message_to_sign.data(), message_to_sign.size(), signature));
 
     return CopySpanToMutableSpan(ByteSpan{ signature.ConstBytes(), signature.Length() }, out_signature_buffer);

--- a/src/credentials/TestOnlyLocalCertificateAuthority.h
+++ b/src/credentials/TestOnlyLocalCertificateAuthority.h
@@ -69,7 +69,7 @@ public:
 
         if (rootKeyPair.Length() != 0)
         {
-            mCurrentStatus = mRootKeypair->Deserialize(rootKeyPair);
+            mCurrentStatus = mRootKeypair->ImportRawKeypair(rootKeyPair.Span());
             SuccessOrExit(mCurrentStatus);
         }
         else

--- a/src/credentials/examples/DeviceAttestationCredsExample.cpp
+++ b/src/credentials/examples/DeviceAttestationCredsExample.cpp
@@ -31,16 +31,6 @@ namespace Examples {
 
 namespace {
 
-// TODO: This should be moved to a method of P256Keypair
-CHIP_ERROR LoadKeypairFromRaw(ByteSpan private_key, ByteSpan public_key, Crypto::P256Keypair & keypair)
-{
-    Crypto::P256SerializedKeypair serialized_keypair;
-    ReturnErrorOnFailure(serialized_keypair.SetLength(private_key.size() + public_key.size()));
-    memcpy(serialized_keypair.Bytes(), public_key.data(), public_key.size());
-    memcpy(serialized_keypair.Bytes() + public_key.size(), private_key.data(), private_key.size());
-    return keypair.Deserialize(serialized_keypair);
-}
-
 class ExampleDACProvider : public DeviceAttestationCredentialsProvider
 {
 public:
@@ -196,7 +186,7 @@ CHIP_ERROR ExampleDACProvider::SignWithDeviceAttestationKey(const ByteSpan & mes
 
     // In a non-exemplary implementation, the public key is not needed here. It is used here merely because
     // Crypto::P256Keypair is only (currently) constructable from raw keys if both private/public keys are present.
-    ReturnErrorOnFailure(LoadKeypairFromRaw(DevelopmentCerts::kDacPrivateKey, DevelopmentCerts::kDacPublicKey, keypair));
+    ReturnErrorOnFailure(keypair.ImportRawKeypair(DevelopmentCerts::kDacPrivateKey, DevelopmentCerts::kDacPublicKey));
     ReturnErrorOnFailure(keypair.ECDSA_sign_msg(message_to_sign.data(), message_to_sign.size(), signature));
 
     return CopySpanToMutableSpan(ByteSpan{ signature.ConstBytes(), signature.Length() }, out_signature_buffer);

--- a/src/credentials/tests/TestCertificationDeclaration.cpp
+++ b/src/credentials/tests/TestCertificationDeclaration.cpp
@@ -363,12 +363,11 @@ static void TestCD_CMSSignAndVerify(nlTestSuite * inSuite, void * inContext)
 
     // Test with known key
     P256Keypair keypair2;
-    P256SerializedKeypair serializedKeypair;
-    memcpy(serializedKeypair.Bytes(), sTestCMS_SignerSerializedKeypair, sizeof(sTestCMS_SignerSerializedKeypair));
-    serializedKeypair.SetLength(sizeof(sTestCMS_SignerSerializedKeypair));
     cdContentIn   = ByteSpan(sTestCMS_CDContent02);
     signedMessage = MutableByteSpan(signedMessageBuf);
-    NL_TEST_ASSERT(inSuite, keypair2.Deserialize(serializedKeypair) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite,
+                   keypair2.ImportRawKeypair(sTestCMS_SignerSerializedKeypair, sizeof(sTestCMS_SignerSerializedKeypair)) ==
+                       CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, CMS_Sign(cdContentIn, signerKeyId, keypair2, signedMessage) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, CMS_Verify(signedMessage, keypair2.Pubkey(), cdContentOut) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, cdContentIn.data_equal(cdContentOut));

--- a/src/credentials/tests/TestFabricTable.cpp
+++ b/src/credentials/tests/TestFabricTable.cpp
@@ -32,7 +32,11 @@
 #include <credentials/TestOnlyLocalCertificateAuthority.h>
 #include <credentials/tests/CHIPCert_test_vectors.h>
 #include <crypto/CHIPCryptoPAL.h>
+#if CHIP_CRYPTO_PSA
+#include <crypto/PSAOperationalKeystore.h>
+#else
 #include <crypto/PersistentStorageOperationalKeystore.h>
+#endif
 #include <lib/asn1/ASN1.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/TestPersistentStorageDelegate.h>
@@ -57,7 +61,9 @@ public:
     {
         mFabricTable.Shutdown();
         mOpCertStore.Finish();
+#if !CHIP_CRYPTO_PSA
         mOpKeyStore.Finish();
+#endif
     }
 
     CHIP_ERROR Init(chip::TestPersistentStorageDelegate * storage)
@@ -67,7 +73,9 @@ public:
         initParams.operationalKeystore = &mOpKeyStore;
         initParams.opCertStore         = &mOpCertStore;
 
+#if !CHIP_CRYPTO_PSA
         ReturnErrorOnFailure(mOpKeyStore.Init(storage));
+#endif
         ReturnErrorOnFailure(mOpCertStore.Init(storage));
         return mFabricTable.Init(initParams);
     }
@@ -76,7 +84,11 @@ public:
 
 private:
     chip::FabricTable mFabricTable;
+#if CHIP_CRYPTO_PSA
+    chip::Crypto::PSAOperationalKeystore mOpKeyStore;
+#else
     chip::PersistentStorageOperationalKeystore mOpKeyStore;
+#endif
     chip::Credentials::PersistentStorageOpCertStore mOpCertStore;
 };
 
@@ -85,21 +97,18 @@ private:
  */
 static CHIP_ERROR LoadTestFabric_Node01_01(nlTestSuite * inSuite, FabricTable & fabricTable, bool doCommit)
 {
-    Crypto::P256SerializedKeypair opKeysSerialized;
     static Crypto::P256Keypair opKey_Node01_01;
 
     FabricIndex fabricIndex;
-    memcpy(opKeysSerialized.Bytes(), TestCerts::sTestCert_Node01_01_PublicKey, TestCerts::sTestCert_Node01_01_PublicKey_Len);
-    memcpy(opKeysSerialized.Bytes() + TestCerts::sTestCert_Node01_01_PublicKey_Len, TestCerts::sTestCert_Node01_01_PrivateKey,
-           TestCerts::sTestCert_Node01_01_PrivateKey_Len);
 
     ByteSpan rcacSpan(TestCerts::sTestCert_Root01_Chip, TestCerts::sTestCert_Root01_Chip_Len);
     ByteSpan icacSpan(TestCerts::sTestCert_ICA01_Chip, TestCerts::sTestCert_ICA01_Chip_Len);
     ByteSpan nocSpan(TestCerts::sTestCert_Node01_01_Chip, TestCerts::sTestCert_Node01_01_Chip_Len);
 
     ReturnErrorOnFailure(
-        opKeysSerialized.SetLength(TestCerts::sTestCert_Node01_01_PublicKey_Len + TestCerts::sTestCert_Node01_01_PrivateKey_Len));
-    ReturnErrorOnFailure(opKey_Node01_01.Deserialize(opKeysSerialized));
+        opKey_Node01_01.ImportRawKeypair(TestCerts::sTestCert_Node01_01_PrivateKey, TestCerts::sTestCert_Node01_01_PrivateKey_Len,
+                                         TestCerts::sTestCert_Node01_01_PublicKey, TestCerts::sTestCert_Node01_01_PublicKey_Len));
+
     ReturnErrorOnFailure(fabricTable.AddNewPendingTrustedRootCert(rcacSpan));
 
     ReturnErrorOnFailure(fabricTable.AddNewPendingFabricWithProvidedOpKey(nocSpan, icacSpan, VendorId::TestVendor1,
@@ -115,20 +124,15 @@ static CHIP_ERROR LoadTestFabric_Node01_01(nlTestSuite * inSuite, FabricTable & 
 
 static CHIP_ERROR LoadTestFabric_Node01_02(nlTestSuite * inSuite, FabricTable & fabricTable, bool doCommit)
 {
-    Crypto::P256SerializedKeypair opKeysSerialized;
     FabricIndex fabricIndex;
     static Crypto::P256Keypair opKey_Node01_02;
-
-    memcpy(opKeysSerialized.Bytes(), TestCerts::sTestCert_Node01_02_PublicKey, TestCerts::sTestCert_Node01_02_PublicKey_Len);
-    memcpy(opKeysSerialized.Bytes() + TestCerts::sTestCert_Node01_02_PublicKey_Len, TestCerts::sTestCert_Node01_02_PrivateKey,
-           TestCerts::sTestCert_Node01_02_PrivateKey_Len);
 
     ByteSpan rcacSpan(TestCerts::sTestCert_Root01_Chip, TestCerts::sTestCert_Root01_Chip_Len);
     ByteSpan nocSpan(TestCerts::sTestCert_Node01_02_Chip, TestCerts::sTestCert_Node01_02_Chip_Len);
 
     ReturnErrorOnFailure(
-        opKeysSerialized.SetLength(TestCerts::sTestCert_Node01_02_PublicKey_Len + TestCerts::sTestCert_Node01_02_PrivateKey_Len));
-    ReturnErrorOnFailure(opKey_Node01_02.Deserialize(opKeysSerialized));
+        opKey_Node01_02.ImportRawKeypair(TestCerts::sTestCert_Node01_02_PrivateKey, TestCerts::sTestCert_Node01_02_PrivateKey_Len,
+                                         TestCerts::sTestCert_Node01_02_PublicKey, TestCerts::sTestCert_Node01_02_PublicKey_Len));
 
     ReturnErrorOnFailure(fabricTable.AddNewPendingTrustedRootCert(rcacSpan));
 
@@ -147,22 +151,17 @@ static CHIP_ERROR LoadTestFabric_Node01_02(nlTestSuite * inSuite, FabricTable & 
  */
 static CHIP_ERROR LoadTestFabric_Node02_01(nlTestSuite * inSuite, FabricTable & fabricTable, bool doCommit)
 {
-    Crypto::P256SerializedKeypair opKeysSerialized;
     FabricIndex fabricIndex;
     static Crypto::P256Keypair opKey_Node02_01;
-
-    memcpy(opKeysSerialized.Bytes(), TestCerts::sTestCert_Node02_01_PublicKey, TestCerts::sTestCert_Node02_01_PublicKey_Len);
-    memcpy(opKeysSerialized.Bytes() + TestCerts::sTestCert_Node02_01_PublicKey_Len, TestCerts::sTestCert_Node02_01_PrivateKey,
-           TestCerts::sTestCert_Node02_01_PrivateKey_Len);
 
     ByteSpan rcacSpan(TestCerts::sTestCert_Root02_Chip, TestCerts::sTestCert_Root02_Chip_Len);
     ByteSpan icacSpan(TestCerts::sTestCert_ICA02_Chip, TestCerts::sTestCert_ICA02_Chip_Len);
     ByteSpan nocSpan(TestCerts::sTestCert_Node02_01_Chip, TestCerts::sTestCert_Node02_01_Chip_Len);
 
     NL_TEST_ASSERT(inSuite,
-                   opKeysSerialized.SetLength(TestCerts::sTestCert_Node02_01_PublicKey_Len +
-                                              TestCerts::sTestCert_Node02_01_PrivateKey_Len) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, opKey_Node02_01.Deserialize(opKeysSerialized) == CHIP_NO_ERROR);
+                   opKey_Node02_01.ImportRawKeypair(
+                       TestCerts::sTestCert_Node02_01_PrivateKey, TestCerts::sTestCert_Node02_01_PrivateKey_Len,
+                       TestCerts::sTestCert_Node02_01_PublicKey, TestCerts::sTestCert_Node02_01_PublicKey_Len) == CHIP_NO_ERROR);
 
     NL_TEST_ASSERT(inSuite, fabricTable.AddNewPendingTrustedRootCert(rcacSpan) == CHIP_NO_ERROR);
 
@@ -694,8 +693,13 @@ void TestBasicAddNocUpdateNocFlow(nlTestSuite * inSuite, void * inContext)
         NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.CommitPendingFabricData());
         NL_TEST_ASSERT_EQUALS(inSuite, fabricTable.FabricCount(), 2);
 
+#if !CHIP_CRYPTO_PSA
         NL_TEST_ASSERT_EQUALS(inSuite, storage.GetNumKeys(),
                               (numStorageAfterFirstAdd + 5)); // 3 opcerts + fabric metadata + 1 operational key
+#else
+        NL_TEST_ASSERT_EQUALS(inSuite, storage.GetNumKeys(),
+                              (numStorageAfterFirstAdd + 4));  // 3 opcerts + fabric metadata
+#endif
 
         // Validate contents
         const auto * fabricInfo = fabricTable.FindFabricWithIndex(2);
@@ -1037,8 +1041,13 @@ void TestAddMultipleSameRootDifferentFabricId(nlTestSuite * inSuite, void * inCo
             NL_TEST_ASSERT(inSuite, fabricInfo->GetFabricLabel().size() == 0);
         }
     }
+
     size_t numStorageKeysAfterFirstAdd = storage.GetNumKeys();
+#if !CHIP_CRYPTO_PSA
     NL_TEST_ASSERT(inSuite, numStorageKeysAfterFirstAdd == 7); // Metadata, index, 3 certs, 1 opkey, last known good time
+#else
+    NL_TEST_ASSERT(inSuite, numStorageKeysAfterFirstAdd == 6); // Metadata, index, 3 certs, last known good time
+#endif
 
     // Second scope: add FabricID 2222, node ID 66, same root as first
     {
@@ -1079,8 +1088,13 @@ void TestAddMultipleSameRootDifferentFabricId(nlTestSuite * inSuite, void * inCo
             NL_TEST_ASSERT(inSuite, fabricInfo->GetFabricLabel().size() == 0);
         }
     }
+
     size_t numStorageKeysAfterSecondAdd = storage.GetNumKeys();
+#if !CHIP_CRYPTO_PSA
     NL_TEST_ASSERT(inSuite, numStorageKeysAfterSecondAdd == (numStorageKeysAfterFirstAdd + 5)); // Add 3 certs, 1 metadata, 1 opkey
+#else
+    NL_TEST_ASSERT(inSuite, numStorageKeysAfterSecondAdd == (numStorageKeysAfterFirstAdd + 4)); // Add 3 certs, 1 metadata, 1 opkey
+#endif
 }
 
 void TestAddMultipleSameFabricIdDifferentRoot(nlTestSuite * inSuite, void * inContext)
@@ -1144,8 +1158,13 @@ void TestAddMultipleSameFabricIdDifferentRoot(nlTestSuite * inSuite, void * inCo
             NL_TEST_ASSERT(inSuite, fabricInfo->GetFabricLabel().size() == 0);
         }
     }
+
     size_t numStorageKeysAfterFirstAdd = storage.GetNumKeys();
+#if !CHIP_CRYPTO_PSA
     NL_TEST_ASSERT(inSuite, numStorageKeysAfterFirstAdd == 7); // Metadata, index, 3 certs, 1 opkey, last known good time
+#else
+    NL_TEST_ASSERT(inSuite, numStorageKeysAfterFirstAdd == 6); // Metadata, index, 3 certs, last known good time
+#endif
 
     // Second scope: add FabricID 1111, node ID 66, different root from first
     {
@@ -1186,8 +1205,13 @@ void TestAddMultipleSameFabricIdDifferentRoot(nlTestSuite * inSuite, void * inCo
             NL_TEST_ASSERT(inSuite, fabricInfo->GetFabricLabel().size() == 0);
         }
     }
+
     size_t numStorageKeysAfterSecondAdd = storage.GetNumKeys();
+#if !CHIP_CRYPTO_PSA
     NL_TEST_ASSERT(inSuite, numStorageKeysAfterSecondAdd == (numStorageKeysAfterFirstAdd + 5)); // Add 3 certs, 1 metadata, 1 opkey
+#else
+    NL_TEST_ASSERT(inSuite, numStorageKeysAfterSecondAdd == (numStorageKeysAfterFirstAdd + 4)); // Add 3 certs, 1 metadata
+#endif
 }
 
 void TestPersistence(nlTestSuite * inSuite, void * inContext)
@@ -1376,10 +1400,17 @@ void TestPersistence(nlTestSuite * inSuite, void * inContext)
         }
     }
 
+#if !CHIP_CRYPTO_PSA
     // Global: Last known good time + fabric index = 2
     // Fabric 1111: Metadata, 1 opkey, RCAC/ICAC/NOC = 5
     // Fabric 2222: Metadata, 1 opkey, RCAC/NOC = 4
     NL_TEST_ASSERT(inSuite, storage.GetNumKeys() == (2 + 5 + 4));
+#else
+    // Global: Last known good time + fabric index = 2
+    // Fabric 1111: Metadata, RCAC/ICAC/NOC = 4
+    // Fabric 2222: Metadata, RCAC/NOC = 3
+    NL_TEST_ASSERT(inSuite, storage.GetNumKeys() == (2 + 4 + 3));
+#endif
 
     // Second scope: Validate that a fresh FabricTable loads the previously committed fabrics on Init.
     {
@@ -1631,8 +1662,13 @@ void TestAddNocFailSafe(nlTestSuite * inSuite, void * inContext)
         NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.CommitPendingFabricData());
         NL_TEST_ASSERT_EQUALS(inSuite, fabricTable.FabricCount(), 1);
 
+#if !CHIP_CRYPTO_PSA
         NL_TEST_ASSERT_EQUALS(inSuite, storage.GetNumKeys(),
                               (numStorageAfterRevert + 5)); // 3 opcerts + fabric metadata + 1 operational key
+#else
+        NL_TEST_ASSERT_EQUALS(inSuite, storage.GetNumKeys(),
+                              (numStorageAfterRevert + 4)); // 3 opcerts + fabric metadata
+#endif
 
         // Validate contents
         const auto * fabricInfo = fabricTable.FindFabricWithIndex(1);
@@ -1777,8 +1813,13 @@ void TestUpdateNocFailSafe(nlTestSuite * inSuite, void * inContext)
         NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.CommitPendingFabricData());
         NL_TEST_ASSERT_EQUALS(inSuite, fabricTable.FabricCount(), 1);
 
+#if !CHIP_CRYPTO_PSA
         NL_TEST_ASSERT_EQUALS(inSuite, storage.GetNumKeys(),
                               (numStorageKeysAtStart + 6)); // 3 opcerts + fabric metadata + 1 operational key + LKGT + fabric index
+#else
+        NL_TEST_ASSERT_EQUALS(inSuite, storage.GetNumKeys(),
+                              (numStorageKeysAtStart + 5)); // 3 opcerts + fabric metadata + LKGT + fabric index
+#endif
 
         // Validate contents
         const auto * fabricInfo = fabricTable.FindFabricWithIndex(1);
@@ -2155,8 +2196,13 @@ void TestFabricLabelChange(nlTestSuite * inSuite, void * inContext)
             NL_TEST_ASSERT(inSuite, fabricInfo->GetFabricLabel().size() == 0);
         }
     }
+
     size_t numStorageKeysAfterFirstAdd = storage.GetNumKeys();
+#if !CHIP_CRYPTO_PSA
     NL_TEST_ASSERT(inSuite, numStorageKeysAfterFirstAdd == 7); // Metadata, index, 3 certs, 1 opkey, last known good time
+#else
+    NL_TEST_ASSERT(inSuite, numStorageKeysAfterFirstAdd == 6); // Metadata, index, 3 certs, last known good time
+#endif
 
     // Second scope: set FabricLabel to "acme fabric", make sure it cannot be reverted
     {
@@ -2386,7 +2432,11 @@ void TestAddNocRootCollision(nlTestSuite * inSuite, void * inContext)
         }
     }
     size_t numStorageKeysAfterFirstAdd = storage.GetNumKeys();
+#if !CHIP_CRYPTO_PSA
     NL_TEST_ASSERT(inSuite, numStorageKeysAfterFirstAdd == 7); // Metadata, index, 3 certs, 1 opkey, last known good time
+#else
+    NL_TEST_ASSERT(inSuite, numStorageKeysAfterFirstAdd == 6); // Metadata, index, 3 certs, last known good time
+#endif
 
     // Second scope: add FabricID 1111, node ID 55 *again* --> Collision of Root/FabricID with existing
     {
@@ -2490,8 +2540,11 @@ void TestAddNocRootCollision(nlTestSuite * inSuite, void * inContext)
         }
     }
     size_t numStorageKeysAfterSecondAdd = storage.GetNumKeys();
-
+#if !CHIP_CRYPTO_PSA
     NL_TEST_ASSERT(inSuite, numStorageKeysAfterSecondAdd == (numStorageKeysAfterFirstAdd + 5)); // Metadata, 3 certs, 1 opkey
+#else
+    NL_TEST_ASSERT(inSuite, numStorageKeysAfterSecondAdd == (numStorageKeysAfterFirstAdd + 4)); // Metadata, 3 certs
+#endif
 }
 
 void TestInvalidChaining(nlTestSuite * inSuite, void * inContext)
@@ -2760,8 +2813,11 @@ void TestCommitMarker(nlTestSuite * inSuite, void * inContext)
         }
         numStorageKeysAfterFirstAdd = storage.GetNumKeys();
 
+#if !CHIP_CRYPTO_PSA
         NL_TEST_ASSERT(inSuite, numStorageKeysAfterFirstAdd == 7); // Metadata, index, 3 certs, 1 opkey, last known good time
-
+#else
+        NL_TEST_ASSERT(inSuite, numStorageKeysAfterFirstAdd == 6); // Metadata, index, 3 certs, last known good time
+#endif
         // The following test requires test methods not available on all builds.
         // TODO: Debug why some CI jobs don't set it properly.
 #if CONFIG_BUILD_FOR_HOST_UNIT_TEST

--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -493,6 +493,20 @@ public:
     CHIP_ERROR Initialize(ECPKeyTarget key_target) override;
 
     /**
+     * @brief Import a raw key pair (bytes) into the keypair
+     * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
+     **/
+    CHIP_ERROR ImportRawKeypair(const uint8_t * key_data, size_t key_data_size);
+    CHIP_ERROR ImportRawKeypair(ByteSpan private_key, ByteSpan public_key)
+    {
+        return ImportRawKeypair(private_key.data(), private_key.size(), public_key.data(), public_key.size());
+    }
+
+    CHIP_ERROR ImportRawKeypair(const uint8_t * private_key, const size_t private_key_size, const uint8_t * public_key,
+                                const size_t public_key_size);
+    CHIP_ERROR ImportRawKeypair(const ByteSpan & key_pair) { return ImportRawKeypair(key_pair.data(), key_pair.size()); }
+
+    /**
      * @brief Serialize the keypair.
      * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
      **/
@@ -544,6 +558,13 @@ public:
 
     /** Release resources associated with this key pair */
     void Clear();
+
+    /**
+     * @brief Copy the keypair in input into this keypair.
+     * @param other The keypair to copy
+     * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
+     **/
+    CHIP_ERROR Copy(const P256Keypair & other);
 
 protected:
     P256PublicKey mPublicKey;

--- a/src/crypto/PSAOperationalKeystore.h
+++ b/src/crypto/PSAOperationalKeystore.h
@@ -49,17 +49,21 @@ protected:
         using P256Keypair::NewCertificateSigningRequest;
         using P256Keypair::Pubkey;
 
-        psa_key_id_t GetKeyId() const;
         bool Exists() const;
-        CHIP_ERROR Generate();
         CHIP_ERROR Destroy();
+        CHIP_ERROR Commit(const P256Keypair & pending);
+
+    private:
+        using P256Keypair::mInitialized;
+        using P256Keypair::mKeypair;
+        psa_key_id_t & mKeyId;
     };
 
     void ReleasePendingKeypair();
 
-    PersistentP256Keypair * mPendingKeypair = nullptr;
-    FabricIndex mPendingFabricIndex         = kUndefinedFabricIndex;
-    bool mIsPendingKeypairActive            = false;
+    P256Keypair * mPendingKeypair   = nullptr;
+    FabricIndex mPendingFabricIndex = kUndefinedFabricIndex;
+    bool mIsPendingKeypairActive    = false;
 };
 
 } // namespace Crypto

--- a/src/crypto/tests/TestPSAOpKeyStore.cpp
+++ b/src/crypto/tests/TestPSAOpKeyStore.cpp
@@ -175,7 +175,7 @@ void TestEphemeralKeys(nlTestSuite * inSuite, void * inContext)
 /**
  *   Test Suite. It lists all the test functions.
  */
-static const nlTest sTests[] = { NL_TEST_DEF("Test Basic Lifecycle of PersistentStorageOperationalKeystore", TestBasicLifeCycle),
+static const nlTest sTests[] = { NL_TEST_DEF("Test Basic Lifecycle of PSAOperationalKeystore", TestBasicLifeCycle),
                                  NL_TEST_DEF("Test ephemeral key management", TestEphemeralKeys), NL_TEST_SENTINEL() };
 
 /**

--- a/src/messaging/tests/MessagingContext.cpp
+++ b/src/messaging/tests/MessagingContext.cpp
@@ -38,7 +38,9 @@ CHIP_ERROR MessagingContext::Init(TransportMgrBase * transport, IOContext * ioCo
 
     ReturnErrorOnFailure(PlatformMemoryUser::Init());
 
+#if !CHIP_CRYPTO_PSA
     ReturnErrorOnFailure(mOpKeyStore.Init(&mStorage));
+#endif
     ReturnErrorOnFailure(mOpCertStore.Init(&mStorage));
 
     chip::FabricTable::InitParams initParams;
@@ -80,7 +82,9 @@ void MessagingContext::Shutdown()
     mSessionManager.Shutdown();
     mFabricTable.Shutdown();
     mOpCertStore.Finish();
+#if !CHIP_CRYPTO_PSA
     mOpKeyStore.Finish();
+#endif
 }
 
 CHIP_ERROR MessagingContext::InitFromExisting(const MessagingContext & existing)

--- a/src/messaging/tests/MessagingContext.h
+++ b/src/messaging/tests/MessagingContext.h
@@ -18,7 +18,11 @@
 
 #include <credentials/PersistentStorageOpCertStore.h>
 #include <crypto/DefaultSessionKeystore.h>
+#if CHIP_CRYPTO_PSA
+#include <crypto/PSAOperationalKeystore.h>
+#else
 #include <crypto/PersistentStorageOperationalKeystore.h>
+#endif
 #include <lib/support/TestPersistentStorageDelegate.h>
 #include <messaging/ExchangeContext.h>
 #include <messaging/ExchangeMgr.h>
@@ -182,7 +186,13 @@ private:
     IOContext * mIOContext;
     TransportMgrBase * mTransport;                // Only needed for InitFromExisting.
     chip::TestPersistentStorageDelegate mStorage; // for SessionManagerInit
+
+#if CHIP_CRYPTO_PSA
+    chip::Crypto::PSAOperationalKeystore mOpKeyStore;
+#else
     chip::PersistentStorageOperationalKeystore mOpKeyStore;
+#endif
+
     chip::Credentials::PersistentStorageOpCertStore mOpCertStore;
     chip::Crypto::DefaultSessionKeystore mSessionKeystore;
 

--- a/src/platform/Ameba/FactoryDataProvider.cpp
+++ b/src/platform/Ameba/FactoryDataProvider.cpp
@@ -129,16 +129,6 @@ const uint8_t kDacPrivateKey[] = {
     0x70, 0x9c, 0xa6, 0x94, 0x6a, 0xf5, 0xf2, 0xf7, 0x53, 0x08, 0x33, 0xa5, 0x2b, 0x44, 0xfb, 0xff,
 };
 
-// TODO: This should be moved to a method of P256Keypair
-CHIP_ERROR LoadKeypairFromRaw(ByteSpan private_key, ByteSpan public_key, Crypto::P256Keypair & keypair)
-{
-    Crypto::P256SerializedKeypair serialized_keypair;
-    ReturnErrorOnFailure(serialized_keypair.SetLength(private_key.size() + public_key.size()));
-    memcpy(serialized_keypair.Bytes(), public_key.data(), public_key.size());
-    memcpy(serialized_keypair.Bytes() + public_key.size(), private_key.data(), private_key.size());
-    return keypair.Deserialize(serialized_keypair);
-}
-
 CHIP_ERROR FactoryDataProvider::Init()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -260,13 +250,13 @@ CHIP_ERROR FactoryDataProvider::SignWithDeviceAttestationKey(const ByteSpan & me
         chip::Crypto::P256PublicKey dacPublicKey;
 
         ReturnErrorOnFailure(chip::Crypto::ExtractPubkeyFromX509Cert(dacCertSpan, dacPublicKey));
-        ReturnErrorOnFailure(
-            LoadKeypairFromRaw(ByteSpan(reinterpret_cast<uint8_t *>(mFactoryData.dac.dac_key.value), mFactoryData.dac.dac_key.len),
-                               ByteSpan(dacPublicKey.Bytes(), dacPublicKey.Length()), keypair));
+        ReturnErrorOnFailure(keypair.ImportRawKeypair(
+            ByteSpan(reinterpret_cast<uint8_t *>(mFactoryData.dac.dac_key.value), mFactoryData.dac.dac_key.len),
+            ByteSpan(dacPublicKey.Bytes(), dacPublicKey.Length())));
     }
     else
     {
-        ReturnErrorOnFailure(LoadKeypairFromRaw(ByteSpan(kDacPrivateKey), ByteSpan(kDacPublicKey), keypair));
+        ReturnErrorOnFailure(keypair.ImportRawKeypair(ByteSpan(kDacPrivateKey), ByteSpan(kDacPublicKey)));
     }
 
     ReturnErrorOnFailure(keypair.ECDSA_sign_msg(messageToSign.data(), messageToSign.size(), signature));

--- a/src/platform/nrfconnect/FactoryDataProvider.cpp
+++ b/src/platform/nrfconnect/FactoryDataProvider.cpp
@@ -29,15 +29,6 @@
 namespace chip {
 namespace {
 
-CHIP_ERROR LoadKeypairFromRaw(ByteSpan privateKey, ByteSpan publicKey, Crypto::P256Keypair & keypair)
-{
-    Crypto::P256SerializedKeypair serializedKeypair;
-    ReturnErrorOnFailure(serializedKeypair.SetLength(privateKey.size() + publicKey.size()));
-    memcpy(serializedKeypair.Bytes(), publicKey.data(), publicKey.size());
-    memcpy(serializedKeypair.Bytes() + publicKey.size(), privateKey.data(), privateKey.size());
-    return keypair.Deserialize(serializedKeypair);
-}
-
 CHIP_ERROR GetFactoryDataString(const FactoryDataString & str, char * buf, size_t bufSize)
 {
     ReturnErrorCodeIf(bufSize < str.len + 1, CHIP_ERROR_BUFFER_TOO_SMALL);
@@ -167,9 +158,9 @@ CHIP_ERROR FactoryDataProvider<FlashFactoryData>::SignWithDeviceAttestationKey(c
     chip::Crypto::P256PublicKey dacPublicKey;
 
     ReturnErrorOnFailure(chip::Crypto::ExtractPubkeyFromX509Cert(dacCertSpan, dacPublicKey));
-    ReturnErrorOnFailure(
-        LoadKeypairFromRaw(ByteSpan(reinterpret_cast<uint8_t *>(mFactoryData.dac_priv_key.data), mFactoryData.dac_priv_key.len),
-                           ByteSpan(dacPublicKey.Bytes(), dacPublicKey.Length()), keypair));
+    ReturnErrorOnFailure(keypair.ImportRawKeypair(
+        ByteSpan(reinterpret_cast<uint8_t *>(mFactoryData.dac_priv_key.data), mFactoryData.dac_priv_key.len),
+        ByteSpan(dacPublicKey.Bytes(), dacPublicKey.Length())));
     ReturnErrorOnFailure(keypair.ECDSA_sign_msg(messageToSign.data(), messageToSign.size(), signature));
 
     return CopySpanToMutableSpan(ByteSpan{ signature.ConstBytes(), signature.Length() }, outSignBuffer);

--- a/src/platform/nxp/mw320/FactoryDataProvider.cpp
+++ b/src/platform/nxp/mw320/FactoryDataProvider.cpp
@@ -28,17 +28,6 @@ extern uint8_t * __FACTORY_DATA_START;
 extern uint32_t __FACTORY_DATA_SIZE;
 
 namespace chip {
-namespace {
-
-CHIP_ERROR LoadKeypairFromRaw(ByteSpan privateKey, ByteSpan publicKey, Crypto::P256Keypair & keypair)
-{
-    Crypto::P256SerializedKeypair serialized_keypair;
-    ReturnErrorOnFailure(serialized_keypair.SetLength(privateKey.size() + publicKey.size()));
-    memcpy(serialized_keypair.Bytes(), publicKey.data(), publicKey.size());
-    memcpy(serialized_keypair.Bytes() + publicKey.size(), privateKey.data(), privateKey.size());
-    return keypair.Deserialize(serialized_keypair);
-}
-} // namespace
 
 namespace DeviceLayer {
 
@@ -195,8 +184,8 @@ CHIP_ERROR FactoryDataProvider::SignWithDeviceAttestationKey(const ByteSpan & me
     ReturnErrorOnFailure(SearchForId(kDacPrivateKeyId, dacPrivateKeySpan.data(), dacPrivateKeySpan.size(), keySize));
     dacPrivateKeySpan.reduce_size(keySize);
 
-    ReturnErrorOnFailure(LoadKeypairFromRaw(ByteSpan(dacPrivateKeySpan.data(), dacPrivateKeySpan.size()),
-                                            ByteSpan(dacPublicKey.Bytes(), dacPublicKey.Length()), keypair));
+    ReturnErrorOnFailure(keypair.ImportRawKeypair(ByteSpan(dacPrivateKeySpan.data(), dacPrivateKeySpan.size()),
+                                                  ByteSpan(dacPublicKey.Bytes(), dacPublicKey.Length())));
     ReturnErrorOnFailure(keypair.ECDSA_sign_msg(messageToSign.data(), messageToSign.size(), signature));
 
     res = CopySpanToMutableSpan(ByteSpan{ signature.ConstBytes(), signature.Length() }, outSignBuffer);

--- a/src/platform/qpg/FactoryDataProvider.cpp
+++ b/src/platform/qpg/FactoryDataProvider.cpp
@@ -26,18 +26,6 @@
 #include "qvCHIP.h"
 
 namespace chip {
-namespace {
-
-CHIP_ERROR LoadKeypairFromRaw(ByteSpan privateKey, ByteSpan publicKey, Crypto::P256Keypair & keypair)
-{
-    Crypto::P256SerializedKeypair serializedKeypair;
-    ReturnErrorOnFailure(serializedKeypair.SetLength(privateKey.size() + publicKey.size()));
-    memcpy(serializedKeypair.Bytes(), publicKey.data(), publicKey.size());
-    memcpy(serializedKeypair.Bytes() + publicKey.size(), privateKey.data(), privateKey.size());
-    return keypair.Deserialize(serializedKeypair);
-}
-
-} // namespace
 
 namespace DeviceLayer {
 
@@ -115,7 +103,7 @@ CHIP_ERROR FactoryDataProvider::SignWithDeviceAttestationKey(const ByteSpan & me
 
     // In a non-exemplary implementation, the public key is not needed here. It is used here merely because
     // Crypto::P256Keypair is only (currently) constructable from raw keys if both private/public keys are present.
-    ReturnErrorOnFailure(LoadKeypairFromRaw(qorvoDacPrivateKey, qorvoDacPublicKey, keypair));
+    ReturnErrorOnFailure(keypair.ImportRawKeypair(qorvoDacPrivateKey, qorvoDacPublicKey));
     ReturnErrorOnFailure(keypair.ECDSA_sign_msg(messageToSign.data(), messageToSign.size(), signature));
 
     return CopySpanToMutableSpan(ByteSpan{ signature.ConstBytes(), signature.Length() }, outSignBuffer);

--- a/src/platform/telink/FactoryDataProvider.cpp
+++ b/src/platform/telink/FactoryDataProvider.cpp
@@ -29,15 +29,6 @@
 namespace chip {
 namespace {
 
-CHIP_ERROR LoadKeypairFromRaw(ByteSpan privateKey, ByteSpan publicKey, Crypto::P256Keypair & keypair)
-{
-    Crypto::P256SerializedKeypair serializedKeypair;
-    ReturnErrorOnFailure(serializedKeypair.SetLength(privateKey.size() + publicKey.size()));
-    memcpy(serializedKeypair.Bytes(), publicKey.data(), publicKey.size());
-    memcpy(serializedKeypair.Bytes() + publicKey.size(), privateKey.data(), privateKey.size());
-    return keypair.Deserialize(serializedKeypair);
-}
-
 CHIP_ERROR GetFactoryDataString(const FactoryDataString & str, char * buf, size_t bufSize)
 {
     ReturnErrorCodeIf(bufSize < str.len + 1, CHIP_ERROR_BUFFER_TOO_SMALL);
@@ -166,9 +157,9 @@ CHIP_ERROR FactoryDataProvider<FlashFactoryData>::SignWithDeviceAttestationKey(c
     chip::Crypto::P256PublicKey dacPublicKey;
 
     ReturnErrorOnFailure(chip::Crypto::ExtractPubkeyFromX509Cert(dacCertSpan, dacPublicKey));
-    ReturnErrorOnFailure(
-        LoadKeypairFromRaw(ByteSpan(reinterpret_cast<uint8_t *>(mFactoryData.dac_priv_key.data), mFactoryData.dac_priv_key.len),
-                           ByteSpan(dacPublicKey.Bytes(), dacPublicKey.Length()), keypair));
+    ReturnErrorOnFailure(keypair.ImportRawKeypair(
+        ByteSpan(reinterpret_cast<uint8_t *>(mFactoryData.dac_priv_key.data), mFactoryData.dac_priv_key.len),
+        ByteSpan(dacPublicKey.Bytes(), dacPublicKey.Length())));
     ReturnErrorOnFailure(keypair.ECDSA_sign_msg(messageToSign.data(), messageToSign.size(), signature));
 
     return CopySpanToMutableSpan(ByteSpan{ signature.ConstBytes(), signature.Length() }, outSignBuffer);

--- a/src/protocols/secure_channel/tests/TestCASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestCASESession.cpp
@@ -270,16 +270,10 @@ CHIP_ERROR InitCredentialSets()
     FabricInfo deviceFabric;
 
     {
-        P256SerializedKeypair opKeysSerialized;
-
         auto deviceOpKey = Platform::MakeUnique<Crypto::P256Keypair>();
-        memcpy(opKeysSerialized.Bytes(), sTestCert_Node01_01_PublicKey, sTestCert_Node01_01_PublicKey_Len);
-        memcpy(opKeysSerialized.Bytes() + sTestCert_Node01_01_PublicKey_Len, sTestCert_Node01_01_PrivateKey,
-               sTestCert_Node01_01_PrivateKey_Len);
 
-        ReturnErrorOnFailure(opKeysSerialized.SetLength(sTestCert_Node01_01_PublicKey_Len + sTestCert_Node01_01_PrivateKey_Len));
-
-        ReturnErrorOnFailure(deviceOpKey->Deserialize(opKeysSerialized));
+        deviceOpKey->ImportRawKeypair(sTestCert_Node01_01_PrivateKey, sTestCert_Node01_01_PrivateKey_Len,
+                                      sTestCert_Node01_01_PublicKey, sTestCert_Node01_01_PublicKey_Len);
 
         // Use an injected operational key for device
         gDeviceOperationalKeystore.Init(1, std::move(deviceOpKey));

--- a/src/transport/tests/TestSessionManager.cpp
+++ b/src/transport/tests/TestSessionManager.cpp
@@ -27,7 +27,11 @@
 #include <credentials/PersistentStorageOpCertStore.h>
 #include <credentials/tests/CHIPCert_unit_test_vectors.h>
 #include <crypto/DefaultSessionKeystore.h>
+#if CHIP_CRYPTO_PSA
+#include <crypto/PSAOperationalKeystore.h>
+#else
 #include <crypto/PersistentStorageOperationalKeystore.h>
+#endif
 #include <lib/core/CHIPCore.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/TestPersistentStorageDelegate.h>
@@ -70,13 +74,17 @@ public:
     ~FabricTableHolder()
     {
         mFabricTable.Shutdown();
+#if !CHIP_CRYPTO_PSA
         mOpKeyStore.Finish();
+#endif
         mOpCertStore.Finish();
     }
 
     CHIP_ERROR Init()
     {
+#if !CHIP_CRYPTO_PSA
         ReturnErrorOnFailure(mOpKeyStore.Init(&mStorage));
+#endif
         ReturnErrorOnFailure(mOpCertStore.Init(&mStorage));
 
         chip::FabricTable::InitParams initParams;
@@ -92,7 +100,11 @@ public:
 private:
     chip::FabricTable mFabricTable;
     chip::TestPersistentStorageDelegate mStorage;
+#if CHIP_CRYPTO_PSA
+    chip::PSAOperationalKeystore mOpKeyStore;
+#else
     chip::PersistentStorageOperationalKeystore mOpKeyStore;
+#endif
     chip::Credentials::PersistentStorageOpCertStore mOpCertStore;
 };
 

--- a/src/transport/tests/TestSessionManagerDispatch.cpp
+++ b/src/transport/tests/TestSessionManagerDispatch.cpp
@@ -27,7 +27,11 @@
 #include <credentials/GroupDataProviderImpl.h>
 #include <credentials/PersistentStorageOpCertStore.h>
 #include <crypto/DefaultSessionKeystore.h>
+#if CHIP_CRYPTO_PSA
+#include <crypto/PSAOperationalKeystore.h>
+#else
 #include <crypto/PersistentStorageOperationalKeystore.h>
+#endif
 #include <lib/core/CHIPCore.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/TestPersistentStorageDelegate.h>
@@ -427,13 +431,17 @@ public:
     ~FabricTableHolder()
     {
         mFabricTable.Shutdown();
+#if !CHIP_CRYPTO_PSA
         mOpKeyStore.Finish();
+#endif
         mOpCertStore.Finish();
     }
 
     CHIP_ERROR Init()
     {
+#if !CHIP_CRYPTO_PSA
         ReturnErrorOnFailure(mOpKeyStore.Init(&mStorage));
+#endif
         ReturnErrorOnFailure(mOpCertStore.Init(&mStorage));
 
         // Initialize Group Data Provider
@@ -457,7 +465,11 @@ public:
 private:
     chip::FabricTable mFabricTable;
     chip::TestPersistentStorageDelegate mStorage;
+#if CHIP_CRYPTO_PSA
+    chip::Crypto::PSAOperationalKeystore mOpKeyStore;
+#else
     chip::PersistentStorageOperationalKeystore mOpKeyStore;
+#endif
     chip::Credentials::PersistentStorageOpCertStore mOpCertStore;
 };
 


### PR DESCRIPTION
The original keypair serialize and deserialize functions for PSA were not secure as they were loading the private key into local storage. It should only be the key id which is being passed around. This PR updates those functions to use the key id instead of the raw private key details. 

As a knock on effect of these changes it was found that the serialize and deserialize functions were also being used to achieve additional functionality, including:
1. Loading raw keypair data into a keypair object
2. Copying a keypair

This PR also includes fixes to add specific methods for loading raw keypair data and copying keypairs for PSA which do not use the serialize and deserialize methods. 

Finally tests have been added for the new LoadKeypairFromRaw() and Copy() methods.

