### PR TITLE
[OIS] Integration tests doc

### DIFF
--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -26,6 +26,7 @@
 -   [Open IoT SDK - Platform Overview](./openiotsdk_platform_overview.md)
 -   [Open IoT SDK - Examples](./openiotsdk_examples.md)
 -   [Open IoT SDK - Unit Tests](./openiotsdk_unit_tests.md)
+-   [Open IoT SDK - Integration Tests](./openiotsdk_integration_tests.md)
 -   [Open IoT SDK - Commissioning](./openiotsdk_commissioning.md)
 -   [Open IoT SDK - Software Update](../examples/openiotsdk_examples_software_update.md)
 

--- a/docs/guides/openiotsdk_examples.md
+++ b/docs/guides/openiotsdk_examples.md
@@ -766,6 +766,11 @@ Example:
 set(APP_TARGET chip-openiotsdk-new-example-example_ns)
 ```
 
+### Integration test
+
+To add the integration test to the new example follow the steps from
+[integration tests guide](./openiotsdk_integration_tests.md#add-new-matters-application-test).
+
 ### Example tools
 
 Add a new example name to the list in the
@@ -800,5 +805,20 @@ Example:
         openiotsdk release new-example \
         examples/new-example/openiotsdk/build/chip-openiotsdk-new-example-example.elf \
         /tmp/bloat_reports/
+...
+```
+
+If the integration test for the new example is available add the additional step
+for its validation in the CI.
+
+Example:
+
+```
+...
+- name: "Test: new-example example"
+    if: steps.build_new_example.outcome == 'success'
+    timeout-minutes: 10
+    run: |
+        scripts/examples/openiotsdk_example.sh -C test new-example
 ...
 ```

--- a/docs/guides/openiotsdk_integration_tests.md
+++ b/docs/guides/openiotsdk_integration_tests.md
@@ -1,0 +1,94 @@
+# Matter Open IoT SDK integration tests
+
+The integration testing approach is to run an application under test inside an
+emulated target through the
+[Arm FVP model for the Corstone-300 MPS3](https://developer.arm.com/downloads/-/arm-ecosystem-fvps).
+We open a communication channel for capturing application output and sending
+data to its input. The
+[Matter Python control](../../src/controller/python/README.md) is used to
+communicate with the device over the network.
+
+Integration tests are written using the [pytest](https://docs.pytest.org)
+framework. Additionally, for discovering, flashing and communicating with the
+`ARM FVP model` target, the
+[pyedmgr](https://iot.sites.arm.com/open-iot-sdk/tools/pyedmgr/) tool is used.
+
+The Open IoT SDK integration tests implementation are located in the
+`src/test_driver/openiotsdk/integration-tests` directory. It contains supported
+tests for Matter applications, common code implementation that can be shared
+between test cases and general integration test settings.
+
+The list of currently supported tests of Matter's applications:
+
+```
+shell
+lock-app
+ota-requestor-app
+all-clusters-app
+tv-app
+unit-tests
+```
+
+## Environment setup
+
+To provide the required environment, use the common
+[Open IoT SDK platform environment](./openiotsdk_examples.md#environment-setup)
+instruction.
+
+## Configuration
+
+The `src/test_driver/openiotsdk/integration-tests/pytest.ini` file contains
+general configuration settings for example logs formatting or markers
+definitions.
+
+The `src/test_driver/openiotsdk/integration-tests/conftest.py` file also serves
+common settings for all available tests. You can find custom command-line
+arguments or sharing fixtures in it.
+
+> 💡 **Notes**:
+>
+> You can also provide your custom settings for running test via command-line.
+> For example generate the test report with
+> [Pytest JSON Report](https://pypi.org/project/pytest-json-report/) plugin.
+>
+> Example:
+>
+> `pytest --json-report --json-report-summary --json-report-file=test_report.json ...`
+
+## Test execution
+
+To execute specific Matter application run `pytest` with pointing to the test
+definition file:
+
+```
+pytest <application_name>/test_app.py
+```
+
+Remember to add necessary command-line arguments according to your test
+environment for run test successfully.
+
+Example:
+
+```
+pytest --json-report --json-report-summary --json-report-file=test_report_lock-app.json --binaryPath=chip-openiotsdk-lock-app-example.elf.elf --fvp=FVP_Corstone_SSE-300_Ethos-U55 --fvpConfig=cs300.conf lock-app/test_app.py
+```
+
+You can also use a helper script or VSCode tasks for testing the supported
+Matter Open IoT SDK examples. For more information see
+[Open IoT SDK examples testing](./openiotsdk_examples.md#testing).
+
+## Add new Matter's application test
+
+To to add new Matter's application test to unit tests project, create the new
+test directory in the `src/test_driver/openiotsdk/integration-tests`. After
+that, in
+`src/test_driver/openiotsdk/integration-tests/<application_name>/test_app.py`
+file implement test cases that validate your application.
+
+The implementation should be `pytest` compliant. You can use the common fixtures
+and functions or available test markers.
+
+> 💡 **Notes**:
+>
+> Remember to update the list of currently supported Matter applications at the
+> top of this document.

--- a/src/test_driver/openiotsdk/integration-tests/all-clusters-app/README.md
+++ b/src/test_driver/openiotsdk/integration-tests/all-clusters-app/README.md
@@ -1,0 +1,29 @@
+# Matter Open IoT SDK All-Clusters-App Integration Test
+
+The Open IoT SDK All-Clusters-App Integration Test validate the
+[all-clusters-app](../../../../../examples/all-clusters-app/openiotsdk/README.md)
+example application.
+
+## Setup-configure-execute
+
+For information on how to setup, configure and execute test refer to
+[Open IoT SDK integration tests](../../../../../docs/guides/openiotsdk_integration_tests.md).
+
+## Additional configuration
+
+-   binary path fixture with the default value:
+    `examples/all-clusters-app/openiotsdk/build/chip-openiotsdk-all-clusters-app-example.elf`
+-   controller configuration fixture:
+    ```
+    {
+        'vendorId': 0xFFF1,
+        'fabricId': 1,
+        'persistentStoragePath': '/tmp/openiotsdk-test-storage.json'
+    }
+    ```
+
+## Test cases
+
+| Smoke test | Commissioning test | Shell command | Clusters               |
+| ---------- | ------------------ | ------------- | ---------------------- |
+| ✅         | ✅                 | ❌            | <li>AccessControl</li> |

--- a/src/test_driver/openiotsdk/integration-tests/lock-app/README.md
+++ b/src/test_driver/openiotsdk/integration-tests/lock-app/README.md
@@ -1,0 +1,29 @@
+# Matter Open IoT SDK Lock-App Integration Test
+
+The Open IoT SDK Lock-App Integration Test validate the
+[lock-app](../../../../../examples/lock-app/openiotsdk/README.md) example
+application.
+
+## Setup-configure-execute
+
+For information on how to setup, configure and execute test refer to
+[Open IoT SDK integration tests](../../../../../docs/guides/openiotsdk_integration_tests.md).
+
+## Additional configuration
+
+-   binary path fixture with the default value:
+    `examples/lock-app/openiotsdk/build/chip-openiotsdk-lock-app-example.elf`
+-   controller configuration fixture:
+    ```
+    {
+        'vendorId': 0xFFF1,
+        'fabricId': 1,
+        'persistentStoragePath': '/tmp/openiotsdk-test-storage.json'
+    }
+    ```
+
+## Test cases
+
+| Smoke test | Commissioning test | Shell command | Clusters          |
+| ---------- | ------------------ | ------------- | ----------------- |
+| ✅         | ✅                 | ❌            | <li>DoorLock</li> |

--- a/src/test_driver/openiotsdk/integration-tests/ota-requestor-app/README.md
+++ b/src/test_driver/openiotsdk/integration-tests/ota-requestor-app/README.md
@@ -1,0 +1,45 @@
+# Matter Open IoT SDK OTA-Requestor-App Integration Test
+
+The Open IoT SDK OTA-Requestor-App Integration Test validate the
+[ota-requestor-app](../../../../../examples/ota-requestor-app/openiotsdk/README.md)
+example application.
+
+## Setup-configure-execute
+
+For information on how to setup, configure and execute test refer to
+[Open IoT SDK integration tests](../../../../../docs/guides/openiotsdk_integration_tests.md).
+
+## Additional configuration
+
+-   binary path fixture with the default value:
+    `examples/lock-app/openiotsdk/build/chip-openiotsdk-lock-app-example.elf`
+-   update binary path fixture with the default value:
+    `'examples/ota-requestor-app/openiotsdk/build/chip-openiotsdk-ota-requestor-app-example.ota'`
+-   controller configuration fixture:
+    ```
+    {
+        'vendorId': 0xFFF1,
+        'fabricId': 1,
+        'persistentStoragePath': '/tmp/openiotsdk-test-storage.json'
+    }
+    ```
+-   OTA provider configuration fixture:
+    ```
+    {
+        'discriminator': '3841',
+        'port': '5580',
+        'filePath': f'{updateBinaryPath}',
+        'persistentStoragePath': '/tmp/openiotsdk-test-ota-provider.json'
+    }
+    ```
+
+## Test cases
+
+| Smoke test | Commissioning test | Shell command | Clusters                            |
+| ---------- | ------------------ | ------------- | ----------------------------------- |
+| ✅         | ✅                 | ❌            | <li>OtaSoftwareUpdateRequestor</li> |
+
+> 💡 **Notes**:
+>
+> The cluster test case triggers the entire firmware update process of
+> downloading and installing a new software image.

--- a/src/test_driver/openiotsdk/integration-tests/shell/README.md
+++ b/src/test_driver/openiotsdk/integration-tests/shell/README.md
@@ -1,0 +1,20 @@
+# Matter Open IoT SDK Shell Integration Test
+
+The Open IoT SDK Shell Integration Test validate the
+[shell](../../../../../examples/shell/openiotsdk/README.md) example application.
+
+## Setup-configure-execute
+
+For information on how to setup, configure and execute test refer to
+[Open IoT SDK integration tests](../../../../../docs/guides/openiotsdk_integration_tests.md).
+
+## Additional configuration
+
+-   binary path fixture with the default value:
+    `examples/shell/openiotsdk/build/chip-openiotsdk-shell-example.elf`
+
+## Test cases
+
+| Smoke test | Commissioning test | Shell command | Clusters |
+| ---------- | ------------------ | ------------- | -------- |
+| ✅         | ❌                 | ✅            | ❌       |

--- a/src/test_driver/openiotsdk/integration-tests/tv-app/README.md
+++ b/src/test_driver/openiotsdk/integration-tests/tv-app/README.md
@@ -1,0 +1,29 @@
+# Matter Open IoT SDK TV-App Integration Test
+
+The Open IoT SDK TV-App Integration Test validate the
+[tv-app](../../../../../examples/tv-app/openiotsdk/README.md) example
+application.
+
+## Setup-configure-execute
+
+For information on how to setup, configure and execute test refer to
+[Open IoT SDK integration tests](../../../../../docs/guides/openiotsdk_integration_tests.md).
+
+## Additional configuration
+
+-   binary path fixture with the default value:
+    `examples/tv-app/openiotsdk/build/chip-openiotsdk-tv-app-example.elf`
+-   controller configuration fixture:
+    ```
+    {
+        'vendorId': 0xFFF1,
+        'fabricId': 1,
+        'persistentStoragePath': '/tmp/openiotsdk-test-storage.json'
+    }
+    ```
+
+## Test cases
+
+| Smoke test | Commissioning test | Shell command | Clusters                                                                                                                                   |
+| ---------- | ------------------ | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| ✅         | ✅                 | ✅            | <li>ApplicationLauncher</li><li>Channel</li><li> ContentLauncher</li><li> KeypadInput</li><li> TargetNavigator</li><li> MediaPlayback</li> |

--- a/src/test_driver/openiotsdk/integration-tests/unit-tests/README.md
+++ b/src/test_driver/openiotsdk/integration-tests/unit-tests/README.md
@@ -1,0 +1,23 @@
+# Matter Open IoT SDK Unit Tests Integration Test
+
+The Open IoT SDK Unit Tests Integration Test validate the specific
+[unit-tests](../../unit-tests/README.md) application.
+
+## Setup-configure-execute
+
+For information on how to setup, configure and execute test refer to
+[Open IoT SDK integration tests](../../../../../docs/guides/openiotsdk_integration_tests.md).
+
+## Additional configuration
+
+-   binary path fixture
+
+> 💡 **Notes**:
+>
+> Application binary path passing is required. Use `--binaryPath` command-line
+> argument with the correct path to the executable.
+
+## Test cases
+
+The test validates the correct launch of the application and waits for the
+unit-test status output. It checks if any test failed.


### PR DESCRIPTION
Add OIS integration test description in docs/guides. Add a link to the integration test doc to the platform guides list. Extend OIS example doc with descriptions of adding an integration test to the new example and its CI validation.
Add README files to each supported test of Matter's applications.

